### PR TITLE
use arc4random when compiled to wasi

### DIFF
--- a/mfbt/RandomNum.cpp
+++ b/mfbt/RandomNum.cpp
@@ -93,7 +93,7 @@ MFBT_API bool GenerateRandomBytesFromOS(void* aBuffer, size_t aLength) {
 
   return !!RtlGenRandom(aBuffer, aLength);
 
-#elif defined(USE_ARC4RANDOM)  // defined(XP_WIN)
+#elif defined(USE_ARC4RANDOM) || defined(__wasi__)  // defined(XP_WIN)
 
   arc4random_buf(aBuffer, aLength);
   return true;

--- a/mfbt/RandomNum.cpp
+++ b/mfbt/RandomNum.cpp
@@ -27,8 +27,9 @@ extern "C" BOOLEAN NTAPI RtlGenRandom(PVOID RandomBuffer,
 
 #endif
 
-#if defined(ANDROID) || defined(XP_DARWIN) || defined(__DragonFly__) || \
-    defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#if defined(ANDROID) || defined(XP_DARWIN) || defined(__DragonFly__) ||    \
+    defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || \
+    defined(__wasi__)
 #  include <stdlib.h>
 #  define USE_ARC4RANDOM
 #endif
@@ -93,7 +94,7 @@ MFBT_API bool GenerateRandomBytesFromOS(void* aBuffer, size_t aLength) {
 
   return !!RtlGenRandom(aBuffer, aLength);
 
-#elif defined(USE_ARC4RANDOM) || defined(__wasi__)  // defined(XP_WIN)
+#elif defined(USE_ARC4RANDOM)  // defined(XP_WIN)
 
   arc4random_buf(aBuffer, aLength);
   return true;


### PR DESCRIPTION
arc4random functions are implemented in wasi-libc -> https://github.com/WebAssembly/wasi-libc/blob/7a21011e98dd9268a33f90fd282db92cbdd1b9d1/libc-top-half/musl/include/stdlib.h#L205-L213

by using arc4random we avoid using the fallback seed implementation which is the current time as a timestamp - using the timestamp fallback causes the first two calls to Math.random to be equal for their first 3-4 decimal places.