### PR TITLE
Add weval support on Fastly branch

### DIFF
--- a/js/moz.build
+++ b/js/moz.build
@@ -30,3 +30,7 @@ with Files("public/**"):
     SCHEDULES.inclusive += ["jittest", "jsreftest"]
 
 SPHINX_TREES["/js"] = "src/doc"
+
+LOCAL_INCLUDES += [
+    "/third_party/weval",
+]

--- a/js/moz.configure
+++ b/js/moz.configure
@@ -1217,6 +1217,20 @@ def is_wasi_target(os):
 set_define("_WASI_EMULATED_PROCESS_CLOCKS", True, when=is_wasi_target)
 set_define("_WASI_EMULATED_GETPID", True, when=is_wasi_target)
 
+# JS C++ interpreter options
+# ===================================================
+
+option(
+    "--enable-js-interp-native-callstack",
+    default=False,
+    help="{Enable|Disable} use of native C++ calls in interpreter for each JS call",
+)
+
+set_define(
+    "ENABLE_JS_INTERP_NATIVE_CALLSTACK",
+    depends_if("--enable-js-interp-native-callstack")(lambda x: True),
+)
+
 # Enable change-array-by-copy
 # ===================================================
 

--- a/js/moz.configure
+++ b/js/moz.configure
@@ -1231,6 +1231,17 @@ set_define(
     depends_if("--enable-js-interp-native-callstack")(lambda x: True),
 )
 
+option(
+    "--enable-js-interp-specialization",
+    default=False,
+    help="{Enable|Disable} separate C++ activations for portion of JS interpretation where PC is statically known",
+)
+
+set_define(
+    "ENABLE_JS_INTERP_SPECIALIZATION",
+    depends_if("--enable-js-interp-specialization")(lambda x: True),
+)
+
 # Enable change-array-by-copy
 # ===================================================
 

--- a/js/moz.configure
+++ b/js/moz.configure
@@ -1253,6 +1253,10 @@ set_define(
     "ENABLE_JS_INTERP_WEVAL",
     depends_if("--enable-js-interp-weval")(lambda x: True),
 )
+set_config(
+    "ENABLE_JS_INTERP_WEVAL",
+    depends_if("--enable-js-interp-weval")(lambda x: True),
+)
 
 # Enable change-array-by-copy
 # ===================================================

--- a/js/moz.configure
+++ b/js/moz.configure
@@ -1242,6 +1242,18 @@ set_define(
     depends_if("--enable-js-interp-specialization")(lambda x: True),
 )
 
+
+option(
+    "--enable-js-interp-weval",
+    default=False,
+    help="{Enable|Disable} annotations for weval, the WebAssembly partial evaluator",
+)
+
+set_define(
+    "ENABLE_JS_INTERP_WEVAL",
+    depends_if("--enable-js-interp-weval")(lambda x: True),
+)
+
 # Enable change-array-by-copy
 # ===================================================
 

--- a/js/src/debugger/moz.build
+++ b/js/src/debugger/moz.build
@@ -29,3 +29,7 @@ UNIFIED_SOURCES = [
     "Script.cpp",
     "Source.cpp",
 ]
+
+LOCAL_INCLUDES += [
+    "/third_party/weval",
+]

--- a/js/src/frontend/moz.build
+++ b/js/src/frontend/moz.build
@@ -96,3 +96,7 @@ SOURCES += [
 
 if CONFIG["FUZZING_INTERFACES"] and CONFIG["LIBFUZZER"]:
     include("/tools/fuzzing/libfuzzer-config.mozbuild")
+
+LOCAL_INCLUDES += [
+    "/third_party/weval",
+]

--- a/js/src/gc/moz.build
+++ b/js/src/gc/moz.build
@@ -59,3 +59,7 @@ UNIFIED_SOURCES += [
 SOURCES += [
     "StoreBuffer.cpp",
 ]
+
+LOCAL_INCLUDES += [
+    "/third_party/weval",
+]

--- a/js/src/irregexp/moz.build
+++ b/js/src/irregexp/moz.build
@@ -47,3 +47,7 @@ if CONFIG["JS_HAS_INTL_API"]:
 # coverage instrumentation in FUZZING mode.
 if CONFIG["FUZZING_INTERFACES"] and CONFIG["LIBFUZZER"]:
     include("/tools/fuzzing/libfuzzer-config.mozbuild")
+
+LOCAL_INCLUDES += [
+    "/third_party/weval",
+]

--- a/js/src/jit-test/tests/gc/bug-1768813.js
+++ b/js/src/jit-test/tests/gc/bug-1768813.js
@@ -16,4 +16,4 @@ function g(i) {
 
 f();
 gczeal(11,3);
-g(5000);
+g(1000);

--- a/js/src/jit/moz.build
+++ b/js/src/jit/moz.build
@@ -293,3 +293,7 @@ GeneratedFile(
 
 if CONFIG["FUZZING_INTERFACES"] or CONFIG["FUZZING_JS_FUZZILLI"]:
     include("/tools/fuzzing/libfuzzer-config.mozbuild")
+
+LOCAL_INCLUDES += [
+    "/third_party/weval",
+]

--- a/js/src/moz.build
+++ b/js/src/moz.build
@@ -650,3 +650,7 @@ if CONFIG["JS_HAS_INTL_API"]:
     ]
 
     USE_LIBS += ["intlcomponents"]
+
+LOCAL_INCLUDES += [
+    "/third_party/weval",
+]

--- a/js/src/shell/moz.build
+++ b/js/src/shell/moz.build
@@ -57,3 +57,7 @@ OBJDIR_FILES.js.src += ["!/dist/bin/js%s" % CONFIG["BIN_SUFFIX"]]
 if CONFIG["OS_ARCH"] == "WASI":
     LDFLAGS += ["-Wl,-z,stack-size=1048576", "-Wl,--stack-first"]
     OS_LIBS += ["wasi-emulated-process-clocks", "wasi-emulated-getpid"]
+
+LOCAL_INCLUDES += [
+    "/third_party/weval",
+]

--- a/js/src/util/moz.build
+++ b/js/src/util/moz.build
@@ -36,3 +36,7 @@ SOURCES += [
 
 # Suppress warnings in third-party code.
 SOURCES["DoubleToString.cpp"].flags += ["-Wno-implicit-fallthrough"]
+
+LOCAL_INCLUDES += [
+    "/third_party/weval",
+]

--- a/js/src/vm/Interpreter.cpp
+++ b/js/src/vm/Interpreter.cpp
@@ -1351,7 +1351,7 @@ again:
   return ok ? SuccessfulReturnContinuation : ErrorReturnContinuation;
 }
 
-#define REGS (activation.regs())
+#define REGS (ictx.activation.regs())
 #define PUSH_COPY(v)                 \
   do {                               \
     *REGS.sp++ = (v);                \
@@ -1981,6 +1981,56 @@ void js::ReportInNotObjectError(JSContext* cx, HandleValue lref,
                             InformalValueTypeName(rref));
 }
 
+/*
+ * Context held during one activation of `Interpret()`, and used
+ * across call-frames of `InterpretScript()`.
+ */
+struct InterpretContext {
+  ActivationEntryMonitor entryMonitor;
+  InterpreterActivation activation;
+
+  /* The script is used frequently, so keep a local copy. */
+  RootedScript script;
+
+  /*
+   * Pool of rooters for use in this interpreter frame. References to these
+   * are used for local variables within interpreter cases. This avoids
+   * creating new rooters each time an interpreter case is entered, and also
+   * correctness pitfalls due to incorrect compilation of destructor calls
+   * around computed gotos.
+   */
+  RootedValue rootValue0, rootValue1;
+  RootedObject rootObject0, rootObject1;
+  RootedFunction rootFunction0;
+  Rooted<JSAtom*> rootAtom0;
+  Rooted<PropertyName*> rootName0;
+  RootedId rootId0;
+  RootedScript rootScript0;
+  Rooted<Scope*> rootScope0;
+  DebugOnly<uint32_t> blockDepth;
+
+  /* State communicated between non-local jumps: */
+  bool interpReturnOK;
+  bool frameHalfInitialized;
+
+  InterpretContext(JSContext* cx, RunState& state, InterpreterFrame* entryFrame)
+      : entryMonitor(cx, entryFrame),
+        activation(state, cx, entryFrame),
+        script(cx),
+        rootValue0(cx),
+        rootValue1(cx),
+        rootObject0(cx),
+        rootObject1(cx),
+        rootFunction0(cx),
+        rootAtom0(cx),
+        rootName0(cx),
+        rootId0(cx),
+        rootScript0(cx),
+        rootScope0(cx),
+        interpReturnOK(false),
+        frameHalfInitialized(false) {}
+};
+
 bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
                                                            RunState& state) {
 /*
@@ -2025,11 +2075,11 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
    * will enable interrupts, and activation.opMask() is or'd with the opcode
    * to implement a simple alternate dispatch.
    */
-#define ADVANCE_AND_DISPATCH(N)                  \
-  JS_BEGIN_MACRO                                 \
-    REGS.pc += (N);                              \
-    SANITY_CHECKS();                             \
-    DISPATCH_TO(*REGS.pc | activation.opMask()); \
+#define ADVANCE_AND_DISPATCH(N)                       \
+  JS_BEGIN_MACRO                                      \
+    REGS.pc += (N);                                   \
+    SANITY_CHECKS();                                  \
+    DISPATCH_TO(*REGS.pc | ictx.activation.opMask()); \
   JS_END_MACRO
 
   /*
@@ -2061,30 +2111,30 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
   /*
    * Initialize code coverage vectors.
    */
-#define INIT_COVERAGE()                                \
-  JS_BEGIN_MACRO                                       \
-    if (!script->hasScriptCounts()) {                  \
-      if (cx->realm()->collectCoverageForDebug()) {    \
-        if (!script->initScriptCounts(cx)) goto error; \
-      }                                                \
-    }                                                  \
+#define INIT_COVERAGE()                                     \
+  JS_BEGIN_MACRO                                            \
+    if (!ictx.script->hasScriptCounts()) {                  \
+      if (cx->realm()->collectCoverageForDebug()) {         \
+        if (!ictx.script->initScriptCounts(cx)) goto error; \
+      }                                                     \
+    }                                                       \
   JS_END_MACRO
 
   /*
    * Increment the code coverage counter associated with the given pc.
    */
-#define COUNT_COVERAGE_PC(PC)                          \
-  JS_BEGIN_MACRO                                       \
-    if (script->hasScriptCounts()) {                   \
-      PCCounts* counts = script->maybeGetPCCounts(PC); \
-      MOZ_ASSERT(counts);                              \
-      counts->numExec()++;                             \
-    }                                                  \
+#define COUNT_COVERAGE_PC(PC)                               \
+  JS_BEGIN_MACRO                                            \
+    if (ictx.script->hasScriptCounts()) {                   \
+      PCCounts* counts = ictx.script->maybeGetPCCounts(PC); \
+      MOZ_ASSERT(counts);                                   \
+      counts->numExec()++;                                  \
+    }                                                       \
   JS_END_MACRO
 
 #define COUNT_COVERAGE_MAIN()                                        \
   JS_BEGIN_MACRO                                                     \
-    jsbytecode* main = script->main();                               \
+    jsbytecode* main = ictx.script->main();                          \
     if (!BytecodeIsJumpTarget(JSOp(*main))) COUNT_COVERAGE_PC(main); \
   JS_END_MACRO
 
@@ -2094,13 +2144,13 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     COUNT_COVERAGE_PC(REGS.pc);                       \
   JS_END_MACRO
 
-#define SET_SCRIPT(s)                                    \
-  JS_BEGIN_MACRO                                         \
-    script = (s);                                        \
-    MOZ_ASSERT(cx->realm() == script->realm());          \
-    if (DebugAPI::hasAnyBreakpointsOrStepMode(script) || \
-        script->hasScriptCounts())                       \
-      activation.enableInterruptsUnconditionally();      \
+#define SET_SCRIPT(s)                                         \
+  JS_BEGIN_MACRO                                              \
+    ictx.script = (s);                                        \
+    MOZ_ASSERT(cx->realm() == ictx.script->realm());          \
+    if (DebugAPI::hasAnyBreakpointsOrStepMode(ictx.script) || \
+        ictx.script->hasScriptCounts())                       \
+      ictx.activation.enableInterruptsUnconditionally();      \
   JS_END_MACRO
 
 #define SANITY_CHECKS()              \
@@ -2133,39 +2183,14 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     return false;
   }
 
-  ActivationEntryMonitor entryMonitor(cx, entryFrame);
-  InterpreterActivation activation(state, cx, entryFrame);
-
-  /* The script is used frequently, so keep a local copy. */
-  RootedScript script(cx);
+  InterpretContext ictx(cx, state, entryFrame);
   SET_SCRIPT(REGS.fp()->script());
 
-  /*
-   * Pool of rooters for use in this interpreter frame. References to these
-   * are used for local variables within interpreter cases. This avoids
-   * creating new rooters each time an interpreter case is entered, and also
-   * correctness pitfalls due to incorrect compilation of destructor calls
-   * around computed gotos.
-   */
-  RootedValue rootValue0(cx), rootValue1(cx);
-  RootedObject rootObject0(cx), rootObject1(cx);
-  RootedFunction rootFunction0(cx);
-  Rooted<JSAtom*> rootAtom0(cx);
-  Rooted<PropertyName*> rootName0(cx);
-  RootedId rootId0(cx);
-  RootedScript rootScript0(cx);
-  Rooted<Scope*> rootScope0(cx);
-  DebugOnly<uint32_t> blockDepth;
-
-  /* State communicated between non-local jumps: */
-  bool interpReturnOK;
-  bool frameHalfInitialized;
-
-  if (!activation.entryFrame()->prologue(cx)) {
+  if (!ictx.activation.entryFrame()->prologue(cx)) {
     goto prologue_error;
   }
 
-  if (!DebugAPI::onEnterFrame(cx, activation.entryFrame())) {
+  if (!DebugAPI::onEnterFrame(cx, ictx.activation.entryFrame())) {
     goto error;
   }
 
@@ -2181,35 +2206,35 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
       bool moreInterrupts = false;
       jsbytecode op = *REGS.pc;
 
-      if (!script->hasScriptCounts() &&
+      if (!ictx.script->hasScriptCounts() &&
           cx->realm()->collectCoverageForDebug()) {
-        if (!script->initScriptCounts(cx)) {
+        if (!ictx.script->initScriptCounts(cx)) {
           goto error;
         }
       }
 
-      if (script->isDebuggee()) {
-        if (DebugAPI::stepModeEnabled(script)) {
+      if (ictx.script->isDebuggee()) {
+        if (DebugAPI::stepModeEnabled(ictx.script)) {
           if (!DebugAPI::onSingleStep(cx)) {
             goto error;
           }
           moreInterrupts = true;
         }
 
-        if (DebugAPI::hasAnyBreakpointsOrStepMode(script)) {
+        if (DebugAPI::hasAnyBreakpointsOrStepMode(ictx.script)) {
           moreInterrupts = true;
         }
 
-        if (DebugAPI::hasBreakpointsAt(script, REGS.pc)) {
+        if (DebugAPI::hasBreakpointsAt(ictx.script, REGS.pc)) {
           if (!DebugAPI::onTrap(cx)) {
             goto error;
           }
         }
       }
 
-      MOZ_ASSERT(activation.opMask() == EnableInterruptsPseudoOpcode);
+      MOZ_ASSERT(ictx.activation.opMask() == EnableInterruptsPseudoOpcode);
       if (!moreInterrupts) {
-        activation.clearInterruptsMask();
+        ictx.activation.clearInterruptsMask();
       }
 
       /* Commence executing the actual opcode. */
@@ -2235,7 +2260,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
 
       // Attempt on-stack replacement into the Baseline Interpreter.
       if (jit::IsBaselineInterpreterEnabled()) {
-        script->incWarmUpCounter();
+        ictx.script->incWarmUpCounter();
 
         jit::MethodStatus status =
             jit::CanEnterBaselineInterpreterAtBranch(cx, REGS.fp());
@@ -2257,16 +2282,16 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
             goto error;
           }
 
-          interpReturnOK = (maybeOsr == jit::JitExec_Ok);
+          ictx.interpReturnOK = (maybeOsr == jit::JitExec_Ok);
 
           // Pop the profiler frame pushed by the interpreter.  (The compiled
           // version of the function popped a copy of the frame pushed by the
           // OSR trampoline.)
           if (wasProfiler) {
-            cx->geckoProfiler().exit(cx, script);
+            cx->geckoProfiler().exit(cx, ictx.script);
           }
 
-          if (activation.entryFrame() != REGS.fp()) {
+          if (ictx.activation.entryFrame() != REGS.fp()) {
             goto jit_return_pop_frame;
           }
           goto leave_on_safe_point;
@@ -2280,7 +2305,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
 
     CASE(ForceInterpreter) {
       // Ensure pattern matching still works.
-      MOZ_ASSERT(script->hasForceInterpreterOp());
+      MOZ_ASSERT(ictx.script->hasForceInterpreterOp());
     }
     END_CASE(ForceInterpreter)
 
@@ -2311,9 +2336,10 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(GetRval)
 
     CASE(EnterWith) {
-      ReservedRooted<Value> val(&rootValue0, REGS.sp[-1]);
+      ReservedRooted<Value> val(&ictx.rootValue0, REGS.sp[-1]);
       REGS.sp--;
-      ReservedRooted<Scope*> scope(&rootScope0, script->getScope(REGS.pc));
+      ReservedRooted<Scope*> scope(&ictx.rootScope0,
+                                   ictx.script->getScope(REGS.pc));
 
       if (!EnterWithOperation(cx, REGS.fp(), val, scope.as<WithScope>())) {
         goto error;
@@ -2338,26 +2364,26 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
       CHECK_BRANCH();
 
     successful_return_continuation:
-      interpReturnOK = true;
+      ictx.interpReturnOK = true;
 
     return_continuation:
-      frameHalfInitialized = false;
+      ictx.frameHalfInitialized = false;
 
     prologue_return_continuation:
 
-      if (activation.entryFrame() != REGS.fp()) {
+      if (ictx.activation.entryFrame() != REGS.fp()) {
         // Stop the engine. (No details about which engine exactly, could be
         // interpreter, Baseline or IonMonkey.)
-        if (MOZ_LIKELY(!frameHalfInitialized)) {
-          interpReturnOK =
-              DebugAPI::onLeaveFrame(cx, REGS.fp(), REGS.pc, interpReturnOK);
+        if (MOZ_LIKELY(!ictx.frameHalfInitialized)) {
+          ictx.interpReturnOK = DebugAPI::onLeaveFrame(cx, REGS.fp(), REGS.pc,
+                                                       ictx.interpReturnOK);
 
           REGS.fp()->epilogue(cx, REGS.pc);
         }
 
       jit_return_pop_frame:
 
-        activation.popInlineFrame(REGS.fp());
+        ictx.activation.popInlineFrame(REGS.fp());
         {
           JSScript* callerScript = REGS.fp()->script();
           if (cx->realm() != callerScript->realm()) {
@@ -2369,10 +2395,10 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
       jit_return:
 
         MOZ_ASSERT(IsInvokePC(REGS.pc));
-        MOZ_ASSERT(cx->realm() == script->realm());
+        MOZ_ASSERT(cx->realm() == ictx.script->realm());
 
         /* Resume execution in the calling frame. */
-        if (MOZ_LIKELY(interpReturnOK)) {
+        if (MOZ_LIKELY(ictx.interpReturnOK)) {
           if (JSOp(*REGS.pc) == JSOp::Resume) {
             ADVANCE_AND_DISPATCH(JSOpLength_Resume);
           }
@@ -2470,8 +2496,8 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
       }
       bool found;
       {
-        ReservedRooted<JSObject*> obj(&rootObject0, &rref.toObject());
-        ReservedRooted<jsid> id(&rootId0);
+        ReservedRooted<JSObject*> obj(&ictx.rootObject0, &rref.toObject());
+        ReservedRooted<jsid> id(&ictx.rootId0);
         FETCH_ELEMENT_ID(-2, id);
         if (!HasProperty(cx, obj, id, &found)) {
           goto error;
@@ -2512,7 +2538,8 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(CheckPrivateField)
 
     CASE(NewPrivateName) {
-      ReservedRooted<JSAtom*> name(&rootAtom0, script->getAtom(REGS.pc));
+      ReservedRooted<JSAtom*> name(&ictx.rootAtom0,
+                                   ictx.script->getAtom(REGS.pc));
 
       auto* symbol = NewPrivateName(cx, name);
       if (!symbol) {
@@ -2562,7 +2589,8 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(EndIter)
 
     CASE(CloseIter) {
-      ReservedRooted<JSObject*> iter(&rootObject0, &REGS.sp[-1].toObject());
+      ReservedRooted<JSObject*> iter(&ictx.rootObject0,
+                                     &REGS.sp[-1].toObject());
       CompletionKind kind = CompletionKind(GET_UINT8(REGS.pc));
       if (!CloseIterOperation(cx, iter, kind)) {
         goto error;
@@ -2622,17 +2650,18 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     CASE(BindGName)
     CASE(BindName) {
       JSOp op = JSOp(*REGS.pc);
-      ReservedRooted<JSObject*> envChain(&rootObject0);
+      ReservedRooted<JSObject*> envChain(&ictx.rootObject0);
       if (op == JSOp::BindName) {
         envChain.set(REGS.fp()->environmentChain());
       } else {
-        MOZ_ASSERT(!script->hasNonSyntacticScope());
+        MOZ_ASSERT(!ictx.script->hasNonSyntacticScope());
         envChain.set(&REGS.fp()->global().lexicalEnvironment());
       }
-      ReservedRooted<PropertyName*> name(&rootName0, script->getName(REGS.pc));
+      ReservedRooted<PropertyName*> name(&ictx.rootName0,
+                                         ictx.script->getName(REGS.pc));
 
       // Assigning to an undeclared name adds a property to the global object.
-      ReservedRooted<JSObject*> env(&rootObject1);
+      ReservedRooted<JSObject*> env(&ictx.rootObject1);
       if (!LookupNameUnqualified(cx, name, envChain, &env)) {
         goto error;
       }
@@ -2832,8 +2861,8 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(Add)
 
     CASE(Sub) {
-      ReservedRooted<Value> lval(&rootValue0, REGS.sp[-2]);
-      ReservedRooted<Value> rval(&rootValue1, REGS.sp[-1]);
+      ReservedRooted<Value> lval(&ictx.rootValue0, REGS.sp[-2]);
+      ReservedRooted<Value> rval(&ictx.rootValue1, REGS.sp[-1]);
       MutableHandleValue res = REGS.stackHandleAt(-2);
       if (!SubOperation(cx, &lval, &rval, res)) {
         goto error;
@@ -2843,8 +2872,8 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(Sub)
 
     CASE(Mul) {
-      ReservedRooted<Value> lval(&rootValue0, REGS.sp[-2]);
-      ReservedRooted<Value> rval(&rootValue1, REGS.sp[-1]);
+      ReservedRooted<Value> lval(&ictx.rootValue0, REGS.sp[-2]);
+      ReservedRooted<Value> rval(&ictx.rootValue1, REGS.sp[-1]);
       MutableHandleValue res = REGS.stackHandleAt(-2);
       if (!MulOperation(cx, &lval, &rval, res)) {
         goto error;
@@ -2854,8 +2883,8 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(Mul)
 
     CASE(Div) {
-      ReservedRooted<Value> lval(&rootValue0, REGS.sp[-2]);
-      ReservedRooted<Value> rval(&rootValue1, REGS.sp[-1]);
+      ReservedRooted<Value> lval(&ictx.rootValue0, REGS.sp[-2]);
+      ReservedRooted<Value> rval(&ictx.rootValue1, REGS.sp[-1]);
       MutableHandleValue res = REGS.stackHandleAt(-2);
       if (!DivOperation(cx, &lval, &rval, res)) {
         goto error;
@@ -2865,8 +2894,8 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(Div)
 
     CASE(Mod) {
-      ReservedRooted<Value> lval(&rootValue0, REGS.sp[-2]);
-      ReservedRooted<Value> rval(&rootValue1, REGS.sp[-1]);
+      ReservedRooted<Value> lval(&ictx.rootValue0, REGS.sp[-2]);
+      ReservedRooted<Value> rval(&ictx.rootValue1, REGS.sp[-1]);
       MutableHandleValue res = REGS.stackHandleAt(-2);
       if (!ModOperation(cx, &lval, &rval, res)) {
         goto error;
@@ -2876,8 +2905,8 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(Mod)
 
     CASE(Pow) {
-      ReservedRooted<Value> lval(&rootValue0, REGS.sp[-2]);
-      ReservedRooted<Value> rval(&rootValue1, REGS.sp[-1]);
+      ReservedRooted<Value> lval(&ictx.rootValue0, REGS.sp[-2]);
+      ReservedRooted<Value> rval(&ictx.rootValue1, REGS.sp[-1]);
       MutableHandleValue res = REGS.stackHandleAt(-2);
       if (!PowOperation(cx, &lval, &rval, res)) {
         goto error;
@@ -2917,8 +2946,9 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(Pos)
 
     CASE(DelName) {
-      ReservedRooted<PropertyName*> name(&rootName0, script->getName(REGS.pc));
-      ReservedRooted<JSObject*> envObj(&rootObject0,
+      ReservedRooted<PropertyName*> name(&ictx.rootName0,
+                                         ictx.script->getName(REGS.pc));
+      ReservedRooted<JSObject*> envObj(&ictx.rootObject0,
                                        REGS.fp()->environmentChain());
 
       PUSH_BOOLEAN(true);
@@ -2934,7 +2964,8 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
       static_assert(JSOpLength_DelProp == JSOpLength_StrictDelProp,
                     "delprop and strictdelprop must be the same size");
       HandleValue val = REGS.stackHandleAt(-1);
-      ReservedRooted<PropertyName*> name(&rootName0, script->getName(REGS.pc));
+      ReservedRooted<PropertyName*> name(&ictx.rootName0,
+                                         ictx.script->getName(REGS.pc));
       bool res = false;
       if (JSOp(*REGS.pc) == JSOp::StrictDelProp) {
         if (!DelPropOperation<true>(cx, val, name, &res)) {
@@ -2971,7 +3002,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(DelElem)
 
     CASE(ToPropertyKey) {
-      ReservedRooted<Value> idval(&rootValue1, REGS.sp[-1]);
+      ReservedRooted<Value> idval(&ictx.rootValue1, REGS.sp[-1]);
       MutableHandleValue res = REGS.stackHandleAt(-1);
       if (!ToPropertyKeyOperation(cx, idval, res)) {
         goto error;
@@ -2997,7 +3028,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(FunctionThis)
 
     CASE(GlobalThis) {
-      MOZ_ASSERT(!script->hasNonSyntacticScope());
+      MOZ_ASSERT(!ictx.script->hasNonSyntacticScope());
       PUSH_OBJECT(*cx->global()->lexicalEnvironment().thisObject());
     }
     END_CASE(GlobalThis)
@@ -3035,7 +3066,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(CheckThisReinit)
 
     CASE(CheckReturn) {
-      ReservedRooted<Value> thisv(&rootValue0, REGS.sp[-1]);
+      ReservedRooted<Value> thisv(&ictx.rootValue0, REGS.sp[-1]);
       MutableHandleValue rval = REGS.stackHandleAt(-1);
       if (!REGS.fp()->checkReturn(cx, thisv, rval)) {
         goto error;
@@ -3044,9 +3075,10 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(CheckReturn)
 
     CASE(GetProp) {
-      ReservedRooted<Value> lval(&rootValue0, REGS.sp[-1]);
+      ReservedRooted<Value> lval(&ictx.rootValue0, REGS.sp[-1]);
       MutableHandleValue res = REGS.stackHandleAt(-1);
-      ReservedRooted<PropertyName*> name(&rootName0, script->getName(REGS.pc));
+      ReservedRooted<PropertyName*> name(&ictx.rootName0,
+                                         ictx.script->getName(REGS.pc));
       if (!GetPropertyOperation(cx, name, lval, res)) {
         goto error;
       }
@@ -3055,13 +3087,14 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(GetProp)
 
     CASE(GetPropSuper) {
-      ReservedRooted<Value> receiver(&rootValue0, REGS.sp[-2]);
+      ReservedRooted<Value> receiver(&ictx.rootValue0, REGS.sp[-2]);
       HandleValue lval = REGS.stackHandleAt(-1);
       MOZ_ASSERT(lval.isObjectOrNull());
       MutableHandleValue rref = REGS.stackHandleAt(-2);
-      ReservedRooted<PropertyName*> name(&rootName0, script->getName(REGS.pc));
+      ReservedRooted<PropertyName*> name(&ictx.rootName0,
+                                         ictx.script->getName(REGS.pc));
 
-      ReservedRooted<JSObject*> obj(&rootObject0);
+      ReservedRooted<JSObject*> obj(&ictx.rootObject0);
       obj = ToObjectFromStackForPropertyAccess(cx, lval, -1, name);
       if (!obj) {
         goto error;
@@ -3078,8 +3111,9 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(GetPropSuper)
 
     CASE(GetBoundName) {
-      ReservedRooted<JSObject*> env(&rootObject0, &REGS.sp[-1].toObject());
-      ReservedRooted<jsid> id(&rootId0, NameToId(script->getName(REGS.pc)));
+      ReservedRooted<JSObject*> env(&ictx.rootObject0, &REGS.sp[-1].toObject());
+      ReservedRooted<jsid> id(&ictx.rootId0,
+                              NameToId(ictx.script->getName(REGS.pc)));
       MutableHandleValue rval = REGS.stackHandleAt(-1);
       if (!GetNameBoundInEnvironment(cx, env, id, rval)) {
         goto error;
@@ -3091,7 +3125,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     CASE(SetIntrinsic) {
       HandleValue value = REGS.stackHandleAt(-1);
 
-      if (!SetIntrinsicOperation(cx, script, REGS.pc, value)) {
+      if (!SetIntrinsicOperation(cx, ictx.script, REGS.pc, value)) {
         goto error;
       }
     }
@@ -3108,10 +3142,10 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
       static_assert(JSOpLength_SetName == JSOpLength_SetGName,
                     "We're sharing the END_CASE so the lengths better match");
 
-      ReservedRooted<JSObject*> env(&rootObject0, &REGS.sp[-2].toObject());
+      ReservedRooted<JSObject*> env(&ictx.rootObject0, &REGS.sp[-2].toObject());
       HandleValue value = REGS.stackHandleAt(-1);
 
-      if (!SetNameOperation(cx, script, REGS.pc, env, value)) {
+      if (!SetNameOperation(cx, ictx.script, REGS.pc, env, value)) {
         goto error;
       }
 
@@ -3128,11 +3162,12 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
       HandleValue lval = REGS.stackHandleAt(lvalIndex);
       HandleValue rval = REGS.stackHandleAt(-1);
 
-      ReservedRooted<jsid> id(&rootId0, NameToId(script->getName(REGS.pc)));
+      ReservedRooted<jsid> id(&ictx.rootId0,
+                              NameToId(ictx.script->getName(REGS.pc)));
 
       bool strict = JSOp(*REGS.pc) == JSOp::StrictSetProp;
 
-      ReservedRooted<JSObject*> obj(&rootObject0);
+      ReservedRooted<JSObject*> obj(&ictx.rootObject0);
       obj = ToObjectFromStackForPropertyAccess(cx, lval, lvalIndex, id);
       if (!obj) {
         goto error;
@@ -3157,11 +3192,12 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
       HandleValue lval = REGS.stackHandleAt(-2);
       MOZ_ASSERT(lval.isObjectOrNull());
       HandleValue rval = REGS.stackHandleAt(-1);
-      ReservedRooted<jsid> id(&rootId0, NameToId(script->getName(REGS.pc)));
+      ReservedRooted<jsid> id(&ictx.rootId0,
+                              NameToId(ictx.script->getName(REGS.pc)));
 
       bool strict = JSOp(*REGS.pc) == JSOp::StrictSetPropSuper;
 
-      ReservedRooted<JSObject*> obj(&rootObject0);
+      ReservedRooted<JSObject*> obj(&ictx.rootObject0);
       obj = ToObjectFromStackForPropertyAccess(cx, lval, -2, id);
       if (!obj) {
         goto error;
@@ -3178,7 +3214,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
 
     CASE(GetElem) {
       int lvalIndex = -2;
-      ReservedRooted<Value> lval(&rootValue0, REGS.sp[lvalIndex]);
+      ReservedRooted<Value> lval(&ictx.rootValue0, REGS.sp[lvalIndex]);
       HandleValue rval = REGS.stackHandleAt(-1);
       MutableHandleValue res = REGS.stackHandleAt(-2);
 
@@ -3191,14 +3227,14 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(GetElem)
 
     CASE(GetElemSuper) {
-      ReservedRooted<Value> receiver(&rootValue0, REGS.sp[-3]);
+      ReservedRooted<Value> receiver(&ictx.rootValue0, REGS.sp[-3]);
       HandleValue index = REGS.stackHandleAt(-2);
       HandleValue lval = REGS.stackHandleAt(-1);
       MOZ_ASSERT(lval.isObjectOrNull());
 
       MutableHandleValue res = REGS.stackHandleAt(-3);
 
-      ReservedRooted<JSObject*> obj(&rootObject0);
+      ReservedRooted<JSObject*> obj(&ictx.rootObject0);
       obj = ToObjectFromStackForPropertyAccess(cx, lval, -1, index);
       if (!obj) {
         goto error;
@@ -3221,14 +3257,14 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
       HandleValue receiver = REGS.stackHandleAt(receiverIndex);
       HandleValue value = REGS.stackHandleAt(-1);
 
-      ReservedRooted<JSObject*> obj(&rootObject0);
+      ReservedRooted<JSObject*> obj(&ictx.rootObject0);
       obj = ToObjectFromStackForPropertyAccess(cx, receiver, receiverIndex,
                                                REGS.stackHandleAt(-2));
       if (!obj) {
         goto error;
       }
 
-      ReservedRooted<jsid> id(&rootId0);
+      ReservedRooted<jsid> id(&ictx.rootId0);
       FETCH_ELEMENT_ID(-2, id);
 
       if (!SetObjectElementOperation(cx, obj, id, value, receiver,
@@ -3251,14 +3287,14 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
       MOZ_ASSERT(lval.isObjectOrNull());
       HandleValue value = REGS.stackHandleAt(-1);
 
-      ReservedRooted<JSObject*> obj(&rootObject0);
+      ReservedRooted<JSObject*> obj(&ictx.rootObject0);
       obj = ToObjectFromStackForPropertyAccess(cx, lval, -2,
                                                REGS.stackHandleAt(-3));
       if (!obj) {
         goto error;
       }
 
-      ReservedRooted<jsid> id(&rootId0);
+      ReservedRooted<jsid> id(&ictx.rootId0);
       FETCH_ELEMENT_ID(-3, id);
 
       bool strict = JSOp(*REGS.pc) == JSOp::StrictSetElemSuper;
@@ -3294,7 +3330,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     CASE(SpreadCall)
     CASE(SpreadSuperCall) {
       if (REGS.fp()->hasPushedGeckoProfilerFrame()) {
-        cx->geckoProfiler().updatePC(cx, script, REGS.pc);
+        cx->geckoProfiler().updatePC(cx, ictx.script, REGS.pc);
       }
       /* FALL THROUGH */
     }
@@ -3313,14 +3349,14 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
       HandleValue arr = REGS.stackHandleAt(-1 - construct);
       MutableHandleValue ret = REGS.stackHandleAt(-3 - construct);
 
-      RootedValue& newTarget = rootValue0;
+      RootedValue& newTarget = ictx.rootValue0;
       if (construct) {
         newTarget = REGS.sp[-1];
       } else {
         newTarget = NullValue();
       }
 
-      if (!SpreadCallOperation(cx, script, REGS.pc, thisv, callee, arr,
+      if (!SpreadCallOperation(cx, ictx.script, REGS.pc, thisv, callee, arr,
                                newTarget, ret)) {
         goto error;
       }
@@ -3351,7 +3387,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
                     "call and supercall must be the same size");
 
       if (REGS.fp()->hasPushedGeckoProfilerFrame()) {
-        cx->geckoProfiler().updatePC(cx, script, REGS.pc);
+        cx->geckoProfiler().updatePC(cx, ictx.script, REGS.pc);
       }
 
       JSOp op = JSOp(*REGS.pc);
@@ -3403,9 +3439,9 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
 
       {
         MOZ_ASSERT(maybeFun);
-        ReservedRooted<JSFunction*> fun(&rootFunction0, maybeFun);
+        ReservedRooted<JSFunction*> fun(&ictx.rootFunction0, maybeFun);
         ReservedRooted<JSScript*> funScript(
-            &rootScript0, JSFunction::getOrCreateScript(cx, fun));
+            &ictx.rootScript0, JSFunction::getOrCreateScript(cx, fun));
         if (!funScript) {
           goto error;
         }
@@ -3418,9 +3454,9 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
           cx->enterRealmOf(funScript);
         }
         auto leaveRealmGuard =
-            mozilla::MakeScopeExit([isCrossRealm, cx, &script] {
+            mozilla::MakeScopeExit([isCrossRealm, cx, &ictx] {
               if (isCrossRealm) {
-                cx->leaveRealm(script->realm());
+                cx->leaveRealm(ictx.script->realm());
               }
             });
 
@@ -3436,7 +3472,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
             case jit::EnterJitStatus::Error:
               goto error;
             case jit::EnterJitStatus::Ok:
-              interpReturnOK = true;
+              ictx.interpReturnOK = true;
               CHECK_BRANCH();
               REGS.sp = args.spAfterCall();
               goto jit_return;
@@ -3450,7 +3486,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
           // entry trampoline for the new frame.
           if (jit::JitOptions.emitInterpreterEntryTrampoline) {
             if (MaybeEnterInterpreterTrampoline(cx, state)) {
-              interpReturnOK = true;
+              ictx.interpReturnOK = true;
               CHECK_BRANCH();
               REGS.sp = args.spAfterCall();
               goto jit_return;
@@ -3462,7 +3498,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
 
         funScript = fun->nonLazyScript();
 
-        if (!activation.pushInlineFrame(args, funScript, construct)) {
+        if (!ictx.activation.pushInlineFrame(args, funScript, construct)) {
           goto error;
         }
         leaveRealmGuard.release();  // We leave the callee's realm when we
@@ -3488,7 +3524,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     }
 
     CASE(OptimizeSpreadCall) {
-      ReservedRooted<Value> val(&rootValue0, REGS.sp[-1]);
+      ReservedRooted<Value> val(&ictx.rootValue0, REGS.sp[-1]);
       MutableHandleValue rval = REGS.stackHandleAt(-1);
 
       if (!OptimizeSpreadCall(cx, val, rval)) {
@@ -3504,10 +3540,11 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(ThrowMsg)
 
     CASE(ImplicitThis) {
-      ReservedRooted<PropertyName*> name(&rootName0, script->getName(REGS.pc));
-      ReservedRooted<JSObject*> envObj(&rootObject0,
+      ReservedRooted<PropertyName*> name(&ictx.rootName0,
+                                         ictx.script->getName(REGS.pc));
+      ReservedRooted<JSObject*> envObj(&ictx.rootObject0,
                                        REGS.fp()->environmentChain());
-      ReservedRooted<JSObject*> env(&rootObject1);
+      ReservedRooted<JSObject*> env(&ictx.rootObject1);
       if (!LookupNameWithGlobalDefault(cx, name, envObj, &env)) {
         goto error;
       }
@@ -3518,11 +3555,12 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(ImplicitThis)
 
     CASE(GetGName) {
-      ReservedRooted<Value> rval(&rootValue0);
-      ReservedRooted<JSObject*> env(&rootObject0,
+      ReservedRooted<Value> rval(&ictx.rootValue0);
+      ReservedRooted<JSObject*> env(&ictx.rootObject0,
                                     &cx->global()->lexicalEnvironment());
-      ReservedRooted<PropertyName*> name(&rootName0, script->getName(REGS.pc));
-      MOZ_ASSERT(!script->hasNonSyntacticScope());
+      ReservedRooted<PropertyName*> name(&ictx.rootName0,
+                                         ictx.script->getName(REGS.pc));
+      MOZ_ASSERT(!ictx.script->hasNonSyntacticScope());
       if (!GetNameOperation(cx, env, name, JSOp(REGS.pc[JSOpLength_GetGName]),
                             &rval)) {
         goto error;
@@ -3533,8 +3571,9 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(GetGName)
 
     CASE(GetName) {
-      ReservedRooted<Value> rval(&rootValue0);
-      ReservedRooted<PropertyName*> name(&rootName0, script->getName(REGS.pc));
+      ReservedRooted<Value> rval(&ictx.rootValue0);
+      ReservedRooted<PropertyName*> name(&ictx.rootName0,
+                                         ictx.script->getName(REGS.pc));
       if (!GetNameOperation(cx, REGS.fp()->environmentChain(), name,
                             JSOp(REGS.pc[JSOpLength_GetName]), &rval)) {
         goto error;
@@ -3548,15 +3587,15 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
       PUSH_NULL();
       MutableHandleValue rval = REGS.stackHandleAt(-1);
       HandleObject envChain = REGS.fp()->environmentChain();
-      if (!GetImportOperation(cx, envChain, script, REGS.pc, rval)) {
+      if (!GetImportOperation(cx, envChain, ictx.script, REGS.pc, rval)) {
         goto error;
       }
     }
     END_CASE(GetImport)
 
     CASE(GetIntrinsic) {
-      ReservedRooted<Value> rval(&rootValue0);
-      if (!GetIntrinsicOperation(cx, script, REGS.pc, &rval)) {
+      ReservedRooted<Value> rval(&ictx.rootValue0);
+      if (!GetIntrinsicOperation(cx, ictx.script, REGS.pc, &rval)) {
         goto error;
       }
 
@@ -3579,7 +3618,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     CASE(Double) { PUSH_COPY(GET_INLINE_VALUE(REGS.pc)); }
     END_CASE(Double)
 
-    CASE(String) { PUSH_STRING(script->getString(REGS.pc)); }
+    CASE(String) { PUSH_STRING(ictx.script->getString(REGS.pc)); }
     END_CASE(String)
 
     CASE(ToString) {
@@ -3601,13 +3640,13 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(Symbol)
 
     CASE(Object) {
-      MOZ_ASSERT(script->treatAsRunOnce());
-      PUSH_OBJECT(*script->getObject(REGS.pc));
+      MOZ_ASSERT(ictx.script->treatAsRunOnce());
+      PUSH_OBJECT(*ictx.script->getObject(REGS.pc));
     }
     END_CASE(Object)
 
     CASE(CallSiteObj) {
-      JSObject* cso = script->getObject(REGS.pc);
+      JSObject* cso = ictx.script->getObject(REGS.pc);
       MOZ_ASSERT(!cso->as<ArrayObject>().isExtensible());
       MOZ_ASSERT(cso->as<ArrayObject>().containsPure(cx->names().raw));
       PUSH_OBJECT(*cso);
@@ -3619,7 +3658,8 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
        * Push a regexp object cloned from the regexp literal object mapped by
        * the bytecode at pc.
        */
-      ReservedRooted<JSObject*> re(&rootObject0, script->getRegExp(REGS.pc));
+      ReservedRooted<JSObject*> re(&ictx.rootObject0,
+                                   ictx.script->getRegExp(REGS.pc));
       JSObject* obj = CloneRegExpObject(cx, re.as<RegExpObject>());
       if (!obj) {
         goto error;
@@ -3670,14 +3710,14 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
 
       i = uint32_t(i) - uint32_t(low);
       if (uint32_t(i) < uint32_t(high - low + 1)) {
-        len = script->tableSwitchCaseOffset(REGS.pc, uint32_t(i)) -
-              script->pcToOffset(REGS.pc);
+        len = ictx.script->tableSwitchCaseOffset(REGS.pc, uint32_t(i)) -
+              ictx.script->pcToOffset(REGS.pc);
       }
       ADVANCE_AND_DISPATCH(len);
     }
 
     CASE(Arguments) {
-      MOZ_ASSERT(script->needsArgsObj());
+      MOZ_ASSERT(ictx.script->needsArgsObj());
       ArgumentsObject* obj = ArgumentsObject::createExpected(cx, REGS.fp());
       if (!obj) {
         goto error;
@@ -3687,7 +3727,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(Arguments)
 
     CASE(Rest) {
-      ReservedRooted<JSObject*> rest(&rootObject0,
+      ReservedRooted<JSObject*> rest(&ictx.rootObject0,
                                      REGS.fp()->createRestParameter(cx));
       if (!rest) {
         goto error;
@@ -3699,7 +3739,8 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     CASE(GetAliasedVar) {
       EnvironmentCoordinate ec = EnvironmentCoordinate(REGS.pc);
       ReservedRooted<Value> val(
-          &rootValue0, REGS.fp()->aliasedEnvironment(ec).aliasedBinding(ec));
+          &ictx.rootValue0,
+          REGS.fp()->aliasedEnvironment(ec).aliasedBinding(ec));
 
       ASSERT_UNINITIALIZED_ALIASED_LEXICAL(val);
 
@@ -3710,7 +3751,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     CASE(GetAliasedDebugVar) {
       EnvironmentCoordinate ec = EnvironmentCoordinate(REGS.pc);
       ReservedRooted<Value> val(
-          &rootValue0,
+          &ictx.rootValue0,
           REGS.fp()->aliasedEnvironmentMaybeDebug(ec).aliasedBinding(ec));
 
       ASSERT_UNINITIALIZED_ALIASED_LEXICAL(val);
@@ -3728,14 +3769,15 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(SetAliasedVar)
 
     CASE(ThrowSetConst) {
-      ReportRuntimeLexicalError(cx, JSMSG_BAD_CONST_ASSIGN, script, REGS.pc);
+      ReportRuntimeLexicalError(cx, JSMSG_BAD_CONST_ASSIGN, ictx.script,
+                                REGS.pc);
       goto error;
     }
     END_CASE(ThrowSetConst)
 
     CASE(CheckLexical) {
       if (REGS.sp[-1].isMagic(JS_UNINITIALIZED_LEXICAL)) {
-        ReportRuntimeLexicalError(cx, JSMSG_UNINITIALIZED_LEXICAL, script,
+        ReportRuntimeLexicalError(cx, JSMSG_UNINITIALIZED_LEXICAL, ictx.script,
                                   REGS.pc);
         goto error;
       }
@@ -3744,7 +3786,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
 
     CASE(CheckAliasedLexical) {
       if (REGS.sp[-1].isMagic(JS_UNINITIALIZED_LEXICAL)) {
-        ReportRuntimeLexicalError(cx, JSMSG_UNINITIALIZED_LEXICAL, script,
+        ReportRuntimeLexicalError(cx, JSMSG_UNINITIALIZED_LEXICAL, ictx.script,
                                   REGS.pc);
         goto error;
       }
@@ -3766,13 +3808,13 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
 
     CASE(InitGLexical) {
       ExtensibleLexicalEnvironmentObject* lexicalEnv;
-      if (script->hasNonSyntacticScope()) {
+      if (ictx.script->hasNonSyntacticScope()) {
         lexicalEnv = &REGS.fp()->extensibleLexicalEnvironment();
       } else {
         lexicalEnv = &cx->global()->lexicalEnvironment();
       }
       HandleValue value = REGS.stackHandleAt(-1);
-      InitGlobalLexicalOperation(cx, lexicalEnv, script, REGS.pc, value);
+      InitGlobalLexicalOperation(cx, lexicalEnv, ictx.script, REGS.pc, value);
     }
     END_CASE(InitGLexical)
 
@@ -3781,7 +3823,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
 
     CASE(GetArg) {
       unsigned i = GET_ARGNO(REGS.pc);
-      if (script->argsObjAliasesFormals()) {
+      if (ictx.script->argsObjAliasesFormals()) {
         PUSH_COPY(REGS.fp()->argsObj().arg(i));
       } else {
         PUSH_COPY(REGS.fp()->unaliasedFormal(i));
@@ -3797,7 +3839,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
 
     CASE(SetArg) {
       unsigned i = GET_ARGNO(REGS.pc);
-      if (script->argsObjAliasesFormals()) {
+      if (ictx.script->argsObjAliasesFormals()) {
         REGS.fp()->argsObj().setArg(i, REGS.sp[-1]);
       } else {
         REGS.fp()->unaliasedFormal(i) = REGS.sp[-1];
@@ -3839,13 +3881,13 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(SetLocal)
 
     CASE(ArgumentsLength) {
-      MOZ_ASSERT(!script->needsArgsObj());
+      MOZ_ASSERT(!ictx.script->needsArgsObj());
       PUSH_INT32(REGS.fp()->numActualArgs());
     }
     END_CASE(ArgumentsLength)
 
     CASE(GetActualArg) {
-      MOZ_ASSERT(!script->needsArgsObj());
+      MOZ_ASSERT(!ictx.script->needsArgsObj());
       uint32_t index = REGS.sp[-1].toInt32();
       REGS.sp[-1] = REGS.fp()->unaliasedActual(index);
     }
@@ -3854,7 +3896,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     CASE(GlobalOrEvalDeclInstantiation) {
       GCThingIndex lastFun = GET_GCTHING_INDEX(REGS.pc);
       HandleObject env = REGS.fp()->environmentChain();
-      if (!GlobalOrEvalDeclInstantiation(cx, env, script, lastFun)) {
+      if (!GlobalOrEvalDeclInstantiation(cx, env, ictx.script, lastFun)) {
         goto error;
       }
     }
@@ -3862,8 +3904,8 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
 
     CASE(Lambda) {
       /* Load the specified function object literal. */
-      ReservedRooted<JSFunction*> fun(&rootFunction0,
-                                      script->getFunction(REGS.pc));
+      ReservedRooted<JSFunction*> fun(&ictx.rootFunction0,
+                                      ictx.script->getFunction(REGS.pc));
       JSObject* obj = Lambda(cx, fun, REGS.fp()->environmentChain());
       if (!obj) {
         goto error;
@@ -3875,8 +3917,9 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(Lambda)
 
     CASE(ToAsyncIter) {
-      ReservedRooted<Value> nextMethod(&rootValue0, REGS.sp[-1]);
-      ReservedRooted<JSObject*> iter(&rootObject1, &REGS.sp[-2].toObject());
+      ReservedRooted<Value> nextMethod(&ictx.rootValue0, REGS.sp[-1]);
+      ReservedRooted<JSObject*> iter(&ictx.rootObject1,
+                                     &REGS.sp[-2].toObject());
       JSObject* asyncIter = CreateAsyncFromSyncIterator(cx, iter, nextMethod);
       if (!asyncIter) {
         goto error;
@@ -3888,7 +3931,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(ToAsyncIter)
 
     CASE(CanSkipAwait) {
-      ReservedRooted<Value> val(&rootValue0, REGS.sp[-1]);
+      ReservedRooted<Value> val(&ictx.rootValue0, REGS.sp[-1]);
       bool canSkip;
       if (!CanSkipAwait(cx, val, &canSkip)) {
         goto error;
@@ -3900,7 +3943,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
 
     CASE(MaybeExtractAwaitValue) {
       MutableHandleValue val = REGS.stackHandleAt(-2);
-      ReservedRooted<Value> canSkip(&rootValue0, REGS.sp[-1]);
+      ReservedRooted<Value> canSkip(&ictx.rootValue0, REGS.sp[-1]);
 
       if (canSkip.toBoolean()) {
         if (!ExtractAwaitValue(cx, val, val)) {
@@ -3912,8 +3955,8 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
 
     CASE(AsyncAwait) {
       MOZ_ASSERT(REGS.stackDepth() >= 2);
-      ReservedRooted<JSObject*> gen(&rootObject1, &REGS.sp[-1].toObject());
-      ReservedRooted<Value> value(&rootValue0, REGS.sp[-2]);
+      ReservedRooted<JSObject*> gen(&ictx.rootObject1, &REGS.sp[-1].toObject());
+      ReservedRooted<Value> value(&ictx.rootValue0, REGS.sp[-2]);
       JSObject* promise =
           AsyncFunctionAwait(cx, gen.as<AsyncFunctionGeneratorObject>(), value);
       if (!promise) {
@@ -3928,8 +3971,8 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     CASE(AsyncResolve) {
       MOZ_ASSERT(REGS.stackDepth() >= 2);
       auto resolveKind = AsyncFunctionResolveKind(GET_UINT8(REGS.pc));
-      ReservedRooted<JSObject*> gen(&rootObject1, &REGS.sp[-1].toObject());
-      ReservedRooted<Value> valueOrReason(&rootValue0, REGS.sp[-2]);
+      ReservedRooted<JSObject*> gen(&ictx.rootObject1, &REGS.sp[-1].toObject());
+      ReservedRooted<Value> valueOrReason(&ictx.rootValue0, REGS.sp[-2]);
       JSObject* promise =
           AsyncFunctionResolve(cx, gen.as<AsyncFunctionGeneratorObject>(),
                                valueOrReason, resolveKind);
@@ -3945,8 +3988,8 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     CASE(SetFunName) {
       MOZ_ASSERT(REGS.stackDepth() >= 2);
       FunctionPrefixKind prefixKind = FunctionPrefixKind(GET_UINT8(REGS.pc));
-      ReservedRooted<Value> name(&rootValue0, REGS.sp[-1]);
-      ReservedRooted<JSFunction*> fun(&rootFunction0,
+      ReservedRooted<Value> name(&ictx.rootValue0, REGS.sp[-1]);
+      ReservedRooted<JSFunction*> fun(&ictx.rootFunction0,
                                       &REGS.sp[-2].toObject().as<JSFunction>());
       if (!SetFunctionName(cx, fun, name, prefixKind)) {
         goto error;
@@ -3968,9 +4011,10 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     CASE(InitHiddenPropSetter) {
       MOZ_ASSERT(REGS.stackDepth() >= 2);
 
-      ReservedRooted<JSObject*> obj(&rootObject0, &REGS.sp[-2].toObject());
-      ReservedRooted<PropertyName*> name(&rootName0, script->getName(REGS.pc));
-      ReservedRooted<JSObject*> val(&rootObject1, &REGS.sp[-1].toObject());
+      ReservedRooted<JSObject*> obj(&ictx.rootObject0, &REGS.sp[-2].toObject());
+      ReservedRooted<PropertyName*> name(&ictx.rootName0,
+                                         ictx.script->getName(REGS.pc));
+      ReservedRooted<JSObject*> val(&ictx.rootObject1, &REGS.sp[-1].toObject());
 
       if (!InitPropGetterSetterOperation(cx, REGS.pc, obj, name, val)) {
         goto error;
@@ -3986,9 +4030,9 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     CASE(InitHiddenElemSetter) {
       MOZ_ASSERT(REGS.stackDepth() >= 3);
 
-      ReservedRooted<JSObject*> obj(&rootObject0, &REGS.sp[-3].toObject());
-      ReservedRooted<Value> idval(&rootValue0, REGS.sp[-2]);
-      ReservedRooted<JSObject*> val(&rootObject1, &REGS.sp[-1].toObject());
+      ReservedRooted<JSObject*> obj(&ictx.rootObject0, &REGS.sp[-3].toObject());
+      ReservedRooted<Value> idval(&ictx.rootValue0, REGS.sp[-2]);
+      ReservedRooted<JSObject*> val(&ictx.rootObject1, &REGS.sp[-1].toObject());
 
       if (!InitElemGetterSetterOperation(cx, REGS.pc, obj, idval, val)) {
         goto error;
@@ -4002,7 +4046,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(Hole)
 
     CASE(NewInit) {
-      JSObject* obj = NewObjectOperation(cx, script, REGS.pc);
+      JSObject* obj = NewObjectOperation(cx, ictx.script, REGS.pc);
 
       if (!obj) {
         goto error;
@@ -4022,7 +4066,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(NewArray)
 
     CASE(NewObject) {
-      JSObject* obj = NewObjectOperation(cx, script, REGS.pc);
+      JSObject* obj = NewObjectOperation(cx, ictx.script, REGS.pc);
       if (!obj) {
         goto error;
       }
@@ -4034,9 +4078,10 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
       MOZ_ASSERT(REGS.stackDepth() >= 2);
 
       if (REGS.sp[-1].isObjectOrNull()) {
-        ReservedRooted<JSObject*> newProto(&rootObject1,
+        ReservedRooted<JSObject*> newProto(&ictx.rootObject1,
                                            REGS.sp[-1].toObjectOrNull());
-        ReservedRooted<JSObject*> obj(&rootObject0, &REGS.sp[-2].toObject());
+        ReservedRooted<JSObject*> obj(&ictx.rootObject0,
+                                      &REGS.sp[-2].toObject());
         MOZ_ASSERT(obj->is<PlainObject>());
 
         if (!SetPrototype(cx, obj, newProto)) {
@@ -4057,12 +4102,13 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
                     "initprop and inithiddenprop must be the same size");
       /* Load the property's initial value into rval. */
       MOZ_ASSERT(REGS.stackDepth() >= 2);
-      ReservedRooted<Value> rval(&rootValue0, REGS.sp[-1]);
+      ReservedRooted<Value> rval(&ictx.rootValue0, REGS.sp[-1]);
 
       /* Load the object being initialized into lval/obj. */
-      ReservedRooted<JSObject*> obj(&rootObject0, &REGS.sp[-2].toObject());
+      ReservedRooted<JSObject*> obj(&ictx.rootObject0, &REGS.sp[-2].toObject());
 
-      ReservedRooted<PropertyName*> name(&rootName0, script->getName(REGS.pc));
+      ReservedRooted<PropertyName*> name(&ictx.rootName0,
+                                         ictx.script->getName(REGS.pc));
 
       if (!InitPropertyOperation(cx, REGS.pc, obj, name, rval)) {
         goto error;
@@ -4079,7 +4125,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
       HandleValue val = REGS.stackHandleAt(-1);
       HandleValue id = REGS.stackHandleAt(-2);
 
-      ReservedRooted<JSObject*> obj(&rootObject0, &REGS.sp[-3].toObject());
+      ReservedRooted<JSObject*> obj(&ictx.rootObject0, &REGS.sp[-3].toObject());
 
       if (!InitElemOperation(cx, REGS.pc, obj, id, val)) {
         goto error;
@@ -4092,7 +4138,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     CASE(InitElemArray) {
       MOZ_ASSERT(REGS.stackDepth() >= 2);
       HandleValue val = REGS.stackHandleAt(-1);
-      ReservedRooted<JSObject*> obj(&rootObject0, &REGS.sp[-2].toObject());
+      ReservedRooted<JSObject*> obj(&ictx.rootObject0, &REGS.sp[-2].toObject());
 
       InitElemArrayOperation(cx, REGS.pc, obj.as<ArrayObject>(), val);
       REGS.sp--;
@@ -4103,7 +4149,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
       MOZ_ASSERT(REGS.stackDepth() >= 3);
       HandleValue val = REGS.stackHandleAt(-1);
 
-      ReservedRooted<JSObject*> obj(&rootObject0, &REGS.sp[-3].toObject());
+      ReservedRooted<JSObject*> obj(&ictx.rootObject0, &REGS.sp[-3].toObject());
 
       uint32_t index = REGS.sp[-2].toInt32();
       if (!InitElemIncOperation(cx, obj.as<ArrayObject>(), index, val)) {
@@ -4129,12 +4175,12 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     CASE(AddRecordProperty) {
       MOZ_ASSERT(REGS.stackDepth() >= 3);
 
-      ReservedRooted<JSObject*> rec(&rootObject0,
+      ReservedRooted<JSObject*> rec(&ictx.rootObject0,
                                     &REGS.sp[-3].toExtendedPrimitive());
       MOZ_ASSERT(rec->is<RecordType>());
 
-      ReservedRooted<Value> key(&rootValue0, REGS.sp[-2]);
-      ReservedRooted<jsid> id(&rootId0);
+      ReservedRooted<Value> key(&ictx.rootValue0, REGS.sp[-2]);
+      ReservedRooted<jsid> id(&ictx.rootId0);
       if (!JS_ValueToId(cx, key, &id)) {
         goto error;
       }
@@ -4180,7 +4226,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     CASE(AddTupleElement) {
       MOZ_ASSERT(REGS.stackDepth() >= 2);
 
-      ReservedRooted<JSObject*> tup(&rootObject0,
+      ReservedRooted<JSObject*> tup(&ictx.rootObject0,
                                     &REGS.sp[-2].toExtendedPrimitive());
       HandleValue val = REGS.stackHandleAt(-1);
 
@@ -4214,7 +4260,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
 
     CASE(Throw) {
       CHECK_BRANCH();
-      ReservedRooted<Value> v(&rootValue0);
+      ReservedRooted<Value> v(&ictx.rootValue0);
       POP_COPY_TO(v);
       MOZ_ALWAYS_FALSE(ThrowOperation(cx, v));
       /* let the code at error try to catch the exception. */
@@ -4222,12 +4268,12 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     }
 
     CASE(Instanceof) {
-      ReservedRooted<Value> rref(&rootValue0, REGS.sp[-1]);
+      ReservedRooted<Value> rref(&ictx.rootValue0, REGS.sp[-1]);
       if (HandleValue(rref).isPrimitive()) {
         ReportValueError(cx, JSMSG_BAD_INSTANCEOF_RHS, -1, rref, nullptr);
         goto error;
       }
-      ReservedRooted<JSObject*> obj(&rootObject0, &rref.toObject());
+      ReservedRooted<JSObject*> obj(&ictx.rootObject0, &rref.toObject());
       bool cond = false;
       if (!InstanceofOperator(cx, obj, REGS.stackHandleAt(-2), &cond)) {
         goto error;
@@ -4245,7 +4291,8 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(Debugger)
 
     CASE(PushLexicalEnv) {
-      ReservedRooted<Scope*> scope(&rootScope0, script->getScope(REGS.pc));
+      ReservedRooted<Scope*> scope(&ictx.rootScope0,
+                                   ictx.script->getScope(REGS.pc));
 
       // Create block environment and push on scope chain.
       if (!REGS.fp()->pushLexicalEnvironment(cx, scope.as<LexicalScope>())) {
@@ -4256,7 +4303,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
 
     CASE(PopLexicalEnv) {
 #ifdef DEBUG
-      Scope* scope = script->lookupScope(REGS.pc);
+      Scope* scope = ictx.script->lookupScope(REGS.pc);
       MOZ_ASSERT(scope);
       MOZ_ASSERT(scope->is<LexicalScope>() || scope->is<ClassBodyScope>());
       MOZ_ASSERT_IF(scope->is<LexicalScope>(),
@@ -4276,7 +4323,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
 
     CASE(DebugLeaveLexicalEnv) {
 #ifdef DEBUG
-      Scope* scope = script->lookupScope(REGS.pc);
+      Scope* scope = ictx.script->lookupScope(REGS.pc);
       MOZ_ASSERT(scope);
       MOZ_ASSERT(scope->is<LexicalScope>() || scope->is<ClassBodyScope>());
       MOZ_ASSERT_IF(scope->is<LexicalScope>(),
@@ -4295,7 +4342,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
 
     CASE(FreshenLexicalEnv) {
 #ifdef DEBUG
-      Scope* scope = script->getScope(REGS.pc);
+      Scope* scope = ictx.script->getScope(REGS.pc);
       auto envChain = REGS.fp()->environmentChain();
       auto* envScope = &envChain->as<BlockLexicalEnvironmentObject>().scope();
       MOZ_ASSERT(scope == envScope);
@@ -4313,7 +4360,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
 
     CASE(RecreateLexicalEnv) {
 #ifdef DEBUG
-      Scope* scope = script->getScope(REGS.pc);
+      Scope* scope = ictx.script->getScope(REGS.pc);
       auto envChain = REGS.fp()->environmentChain();
       auto* envScope = &envChain->as<BlockLexicalEnvironmentObject>().scope();
       MOZ_ASSERT(scope == envScope);
@@ -4330,7 +4377,8 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(RecreateLexicalEnv)
 
     CASE(PushClassBodyEnv) {
-      ReservedRooted<Scope*> scope(&rootScope0, script->getScope(REGS.pc));
+      ReservedRooted<Scope*> scope(&ictx.rootScope0,
+                                   ictx.script->getScope(REGS.pc));
 
       if (!REGS.fp()->pushClassBodyEnvironment(cx,
                                                scope.as<ClassBodyScope>())) {
@@ -4340,7 +4388,8 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(PushClassBodyEnv)
 
     CASE(PushVarEnv) {
-      ReservedRooted<Scope*> scope(&rootScope0, script->getScope(REGS.pc));
+      ReservedRooted<Scope*> scope(&ictx.rootScope0,
+                                   ictx.script->getScope(REGS.pc));
 
       if (!REGS.fp()->pushVarEnvironment(cx, scope)) {
         goto error;
@@ -4361,15 +4410,15 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
 
     CASE(InitialYield) {
       MOZ_ASSERT(!cx->isExceptionPending());
-      MOZ_ASSERT_IF(script->isModule() && script->isAsync(),
+      MOZ_ASSERT_IF(ictx.script->isModule() && ictx.script->isAsync(),
                     REGS.fp()->isModuleFrame());
-      MOZ_ASSERT_IF(!script->isModule() && script->isAsync(),
+      MOZ_ASSERT_IF(!ictx.script->isModule() && ictx.script->isAsync(),
                     REGS.fp()->isFunctionFrame());
-      ReservedRooted<JSObject*> obj(&rootObject0, &REGS.sp[-1].toObject());
+      ReservedRooted<JSObject*> obj(&ictx.rootObject0, &REGS.sp[-1].toObject());
       POP_RETURN_VALUE();
       MOZ_ASSERT(REGS.stackDepth() == 0);
       if (!AbstractGeneratorObject::suspend(cx, obj, REGS.fp(), REGS.pc,
-                                            script->nfixed())) {
+                                            ictx.script->nfixed())) {
         goto error;
       }
       goto successful_return_continuation;
@@ -4378,14 +4427,14 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     CASE(Yield)
     CASE(Await) {
       MOZ_ASSERT(!cx->isExceptionPending());
-      MOZ_ASSERT_IF(script->isModule() && script->isAsync(),
+      MOZ_ASSERT_IF(ictx.script->isModule() && ictx.script->isAsync(),
                     REGS.fp()->isModuleFrame());
-      MOZ_ASSERT_IF(!script->isModule() && script->isAsync(),
+      MOZ_ASSERT_IF(!ictx.script->isModule() && ictx.script->isAsync(),
                     REGS.fp()->isFunctionFrame());
-      ReservedRooted<JSObject*> obj(&rootObject0, &REGS.sp[-1].toObject());
+      ReservedRooted<JSObject*> obj(&ictx.rootObject0, &REGS.sp[-1].toObject());
       if (!AbstractGeneratorObject::suspend(
               cx, obj, REGS.fp(), REGS.pc,
-              script->nfixed() + REGS.stackDepth() - 2)) {
+              ictx.script->nfixed() + REGS.stackDepth() - 2)) {
         goto error;
       }
 
@@ -4405,11 +4454,11 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
       int32_t kindInt = REGS.sp[-1].toInt32();
       GeneratorResumeKind resumeKind = IntToResumeKind(kindInt);
       if (MOZ_UNLIKELY(resumeKind != GeneratorResumeKind::Next)) {
-        ReservedRooted<Value> val(&rootValue0, REGS.sp[-3]);
+        ReservedRooted<Value> val(&ictx.rootValue0, REGS.sp[-3]);
         Rooted<AbstractGeneratorObject*> gen(
             cx, &REGS.sp[-2].toObject().as<AbstractGeneratorObject>());
-        MOZ_ALWAYS_FALSE(GeneratorThrowOrReturn(cx, activation.regs().fp(), gen,
-                                                val, resumeKind));
+        MOZ_ALWAYS_FALSE(GeneratorThrowOrReturn(cx, ictx.activation.regs().fp(),
+                                                gen, val, resumeKind));
         goto error;
       }
       REGS.sp -= 2;
@@ -4420,14 +4469,14 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
       {
         Rooted<AbstractGeneratorObject*> gen(
             cx, &REGS.sp[-3].toObject().as<AbstractGeneratorObject>());
-        ReservedRooted<Value> val(&rootValue0, REGS.sp[-2]);
-        ReservedRooted<Value> resumeKindVal(&rootValue1, REGS.sp[-1]);
+        ReservedRooted<Value> val(&ictx.rootValue0, REGS.sp[-2]);
+        ReservedRooted<Value> resumeKindVal(&ictx.rootValue1, REGS.sp[-1]);
 
         // popInlineFrame expects there to be an additional value on the stack
         // to pop off, so leave "gen" on the stack.
         REGS.sp -= 1;
 
-        if (!AbstractGeneratorObject::resume(cx, activation, gen, val,
+        if (!AbstractGeneratorObject::resume(cx, ictx.activation, gen, val,
                                              resumeKindVal)) {
           goto error;
         }
@@ -4466,7 +4515,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(AfterYield)
 
     CASE(FinalYieldRval) {
-      ReservedRooted<JSObject*> gen(&rootObject0, &REGS.sp[-1].toObject());
+      ReservedRooted<JSObject*> gen(&ictx.rootObject0, &REGS.sp[-1].toObject());
       REGS.sp--;
       AbstractGeneratorObject::finalSuspend(gen);
       goto successful_return_continuation;
@@ -4492,11 +4541,12 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(BuiltinObject)
 
     CASE(FunWithProto) {
-      ReservedRooted<JSObject*> proto(&rootObject1, &REGS.sp[-1].toObject());
+      ReservedRooted<JSObject*> proto(&ictx.rootObject1,
+                                      &REGS.sp[-1].toObject());
 
       /* Load the specified function object literal. */
-      ReservedRooted<JSFunction*> fun(&rootFunction0,
-                                      script->getFunction(REGS.pc));
+      ReservedRooted<JSFunction*> fun(&ictx.rootFunction0,
+                                      ictx.script->getFunction(REGS.pc));
 
       JSObject* obj =
           FunWithProtoOperation(cx, fun, REGS.fp()->environmentChain(), proto);
@@ -4556,7 +4606,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(NewTarget)
 
     CASE(ImportMeta) {
-      JSObject* metaObject = ImportMetaOperation(cx, script);
+      JSObject* metaObject = ImportMetaOperation(cx, ictx.script);
       if (!metaObject) {
         goto error;
       }
@@ -4566,14 +4616,14 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(ImportMeta)
 
     CASE(DynamicImport) {
-      ReservedRooted<Value> options(&rootValue0, REGS.sp[-1]);
+      ReservedRooted<Value> options(&ictx.rootValue0, REGS.sp[-1]);
       REGS.sp--;
 
-      ReservedRooted<Value> specifier(&rootValue1);
+      ReservedRooted<Value> specifier(&ictx.rootValue1);
       POP_COPY_TO(specifier);
 
       JSObject* promise =
-          StartDynamicModuleImport(cx, script, specifier, options);
+          StartDynamicModuleImport(cx, ictx.script, specifier, options);
       if (!promise) goto error;
 
       PUSH_OBJECT(*promise);
@@ -4598,7 +4648,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     END_CASE(SuperFun)
 
     CASE(CheckObjCoercible) {
-      ReservedRooted<Value> checkVal(&rootValue0, REGS.sp[-1]);
+      ReservedRooted<Value> checkVal(&ictx.rootValue0, REGS.sp[-1]);
       if (checkVal.isNullOrUndefined()) {
         MOZ_ALWAYS_FALSE(ThrowObjectCoercible(cx, checkVal));
         goto error;
@@ -4608,7 +4658,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
 
     CASE(DebugCheckSelfHosted) {
 #ifdef DEBUG
-      ReservedRooted<Value> checkVal(&rootValue0, REGS.sp[-1]);
+      ReservedRooted<Value> checkVal(&ictx.rootValue0, REGS.sp[-1]);
       if (!Debug_CheckSelfHosted(cx, checkVal)) {
         goto error;
       }
@@ -4642,7 +4692,7 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
     }
     END_CASE(ToNumeric)
 
-    CASE(BigInt) { PUSH_BIGINT(script->getBigInt(REGS.pc)); }
+    CASE(BigInt) { PUSH_BIGINT(ictx.script->getBigInt(REGS.pc)); }
     END_CASE(BigInt)
 
     DEFAULT() {
@@ -4663,7 +4713,7 @@ error:
       goto successful_return_continuation;
 
     case ErrorReturnContinuation:
-      interpReturnOK = false;
+      ictx.interpReturnOK = false;
       goto return_continuation;
 
     case CatchContinuation:
@@ -4674,9 +4724,9 @@ error:
        * Push (exception, true) pair for finally to indicate that we
        * should rethrow the exception.
        */
-      ReservedRooted<Value> exception(&rootValue0);
+      ReservedRooted<Value> exception(&ictx.rootValue0);
       if (!cx->getPendingException(&exception)) {
-        interpReturnOK = false;
+        ictx.interpReturnOK = false;
         goto return_continuation;
       }
       PUSH_COPY(exception);
@@ -4689,9 +4739,9 @@ error:
   MOZ_CRASH("Invalid HandleError continuation");
 
 exit:
-  if (MOZ_LIKELY(!frameHalfInitialized)) {
-    interpReturnOK =
-        DebugAPI::onLeaveFrame(cx, REGS.fp(), REGS.pc, interpReturnOK);
+  if (MOZ_LIKELY(!ictx.frameHalfInitialized)) {
+    ictx.interpReturnOK =
+        DebugAPI::onLeaveFrame(cx, REGS.fp(), REGS.pc, ictx.interpReturnOK);
 
     REGS.fp()->epilogue(cx, REGS.pc);
   }
@@ -4704,15 +4754,15 @@ exit:
    */
 leave_on_safe_point:
 
-  if (interpReturnOK) {
-    state.setReturnValue(activation.entryFrame()->returnValue());
+  if (ictx.interpReturnOK) {
+    state.setReturnValue(ictx.activation.entryFrame()->returnValue());
   }
 
-  return interpReturnOK;
+  return ictx.interpReturnOK;
 
 prologue_error:
-  interpReturnOK = false;
-  frameHalfInitialized = true;
+  ictx.interpReturnOK = false;
+  ictx.frameHalfInitialized = true;
   goto prologue_return_continuation;
 }
 

--- a/js/src/vm/Interpreter.cpp
+++ b/js/src/vm/Interpreter.cpp
@@ -78,6 +78,7 @@
 #include "vm/ObjectOperations-inl.h"
 #include "vm/PlainObject-inl.h"  // js::CopyInitializerObject, js::CreateThis
 #include "vm/Probes-inl.h"
+#include "vm/SharedStencil-inl.h"
 #include "vm/Stack-inl.h"
 
 using namespace js;

--- a/js/src/vm/Interpreter.cpp
+++ b/js/src/vm/Interpreter.cpp
@@ -2164,6 +2164,20 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
   return ret;
 }
 
+enum class InterpretCallResult : uint32_t {
+  SuccessAdvancePastCall,
+  Error,
+#ifndef ENABLE_JS_INTERP_WEVAL
+  SuccessZeroAdvance,
+  PrologueError,
+  JitReturn,
+#endif
+};
+
+static InterpretCallResult InterpretCall(JSContext* cx, RunState& state,
+                                         InterpretContext& ictx,
+                                         jsbytecode* pc);
+
 static MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER bool InterpretInner(
     JSContext* cx, RunState& state, InterpretContext& ictx, jsbytecode* pc,
     ImmutableScriptData* isd, InterpretEntryKind entryKind) {
@@ -3586,165 +3600,21 @@ initial_dispatch:
     CASE(CallIter)
     CASE(CallContentIter)
     CASE(SuperCall) {
-      static_assert(JSOpLength_Call == JSOpLength_New,
-                    "call and new must be the same size");
-      static_assert(JSOpLength_Call == JSOpLength_CallContent,
-                    "call and call-content must be the same size");
-      static_assert(JSOpLength_Call == JSOpLength_CallIgnoresRv,
-                    "call and call-ignores-rv must be the same size");
-      static_assert(JSOpLength_Call == JSOpLength_CallIter,
-                    "call and calliter must be the same size");
-      static_assert(JSOpLength_Call == JSOpLength_CallContentIter,
-                    "call and call-content-iter must be the same size");
-      static_assert(JSOpLength_Call == JSOpLength_SuperCall,
-                    "call and supercall must be the same size");
-
-      if (REGS.fp()->hasPushedGeckoProfilerFrame()) {
-        cx->geckoProfiler().updatePC(cx, ictx.script, pc);
-      }
-
-      JSOp op = JSOp(*pc);
-      MaybeConstruct construct = MaybeConstruct(
-          op == JSOp::New || op == JSOp::NewContent || op == JSOp::SuperCall);
-      bool ignoresReturnValue = op == JSOp::CallIgnoresRv;
-      unsigned argStackSlots = GET_ARGC(pc) + construct;
-
-      MOZ_ASSERT(REGS.stackDepth() >= 2u + GET_ARGC(pc));
-      CallArgs args =
-          CallArgsFromSp(argStackSlots, REGS.sp, construct, ignoresReturnValue);
-
-      JSFunction* maybeFun;
-      bool isFunction = IsFunctionObject(args.calleev(), &maybeFun);
-
-      // Use the slow path if the callee is not an interpreted function, if we
-      // have to throw an exception, or if we might have to invoke the
-      // OnNativeCall hook for a self-hosted builtin.
-      if (!isFunction || !maybeFun->isInterpreted() ||
-          (construct && !maybeFun->isConstructor()) ||
-          (!construct && maybeFun->isClassConstructor()) ||
-          cx->insideDebuggerEvaluationWithOnNativeCallHook) {
-        if (construct) {
-          CallReason reason = op == JSOp::NewContent ? CallReason::CallContent
-                                                     : CallReason::Call;
-          if (!ConstructFromStack(cx, args, reason)) {
-            goto error;
-          }
-        } else {
-          if ((op == JSOp::CallIter || op == JSOp::CallContentIter) &&
-              args.calleev().isPrimitive()) {
-            MOZ_ASSERT(args.length() == 0, "thisv must be on top of the stack");
-            ReportValueError(cx, JSMSG_NOT_ITERABLE, -1, args.thisv(), nullptr);
-            goto error;
-          }
-
-          CallReason reason =
-              (op == JSOp::CallContent || op == JSOp::CallContentIter)
-                  ? CallReason::CallContent
-                  : CallReason::Call;
-          if (!CallFromStack(cx, args, reason)) {
-            goto error;
-          }
-        }
-        Value* newsp = args.spAfterCall();
-        REGS.sp = newsp;
-        ADVANCE_AND_DISPATCH(JSOpLength_Call);
-      }
-
-      {
-        MOZ_ASSERT(maybeFun);
-        ReservedRooted<JSFunction*> fun(&ictx.rootFunction0, maybeFun);
-        ReservedRooted<JSScript*> funScript(
-            &ictx.rootScript0, JSFunction::getOrCreateScript(cx, fun));
-        if (!funScript) {
+      switch (InterpretCall(cx, state, ictx, pc)) {
+        case InterpretCallResult::SuccessAdvancePastCall:
+          ADVANCE_AND_DISPATCH(JSOpLength_Call);
+        case InterpretCallResult::Error:
           goto error;
-        }
-
-        // Enter the callee's realm if this is a cross-realm call. Use
-        // MakeScopeExit to leave this realm on all error/JIT-return paths
-        // below.
-        const bool isCrossRealm = cx->realm() != funScript->realm();
-        if (isCrossRealm) {
-          cx->enterRealmOf(funScript);
-        }
-        auto leaveRealmGuard =
-            mozilla::MakeScopeExit([isCrossRealm, cx, &ictx] {
-              if (isCrossRealm) {
-                cx->leaveRealm(ictx.script->realm());
-              }
-            });
-
-        if (construct && !MaybeCreateThisForConstructor(cx, args)) {
-          goto error;
-        }
-
 #ifndef ENABLE_JS_INTERP_WEVAL
-        {
-          InvokeState state(cx, args, construct);
-
-          jit::EnterJitStatus status = jit::MaybeEnterJit(cx, state);
-          switch (status) {
-            case jit::EnterJitStatus::Error:
-              goto error;
-            case jit::EnterJitStatus::Ok:
-              ictx.interpReturnOK = true;
-              CHECK_BRANCH();
-              REGS.sp = args.spAfterCall();
-              goto jit_return;
-            case jit::EnterJitStatus::NotEntered:
-              break;
-          }
-
-#  ifdef NIGHTLY_BUILD
-          // If entry trampolines are enabled, call back into
-          // MaybeEnterInterpreterTrampoline so we can generate an
-          // entry trampoline for the new frame.
-          if (jit::JitOptions.emitInterpreterEntryTrampoline) {
-            if (MaybeEnterInterpreterTrampoline(cx, state)) {
-              ictx.interpReturnOK = true;
-              CHECK_BRANCH();
-              REGS.sp = args.spAfterCall();
-              goto jit_return;
-            }
-            goto error;
-          }
-#  endif  // NIGHTLY_BUILD
-        }
-#endif  // !ENABLE_JS_INTERP_WEVAL
-
-        funScript = fun->nonLazyScript();
-
-        if (!ictx.activation.pushInlineFrame(args, funScript, construct)) {
-          goto error;
-        }
-        leaveRealmGuard.release();  // We leave the callee's realm when we
-                                    // call popInlineFrame.
+        case InterpretCallResult::SuccessZeroAdvance:
+          ADVANCE_AND_DISPATCH(0);
+        case InterpretCallResult::PrologueError:
+          goto prologue_error;
+        case InterpretCallResult::JitReturn:
+          goto jit_return;
+#endif
       }
-
-      SET_SCRIPT(REGS.fp()->script());
-
-#ifdef ENABLE_JS_INTERP_NATIVE_CALLSTACK
-      bool ret;
-      CALL_INNER(ret);
-      if (!ret) {
-        goto error;
-      }
-      ADVANCE_AND_DISPATCH(JSOpLength_Call);
-#else   // ENABLE_JS_INTERP_NATIVE_CALLSTACK
-      if (!REGS.fp()->prologue(cx)) {
-        goto prologue_error;
-      }
-
-      if (!DebugAPI::onEnterFrame(cx, REGS.fp())) {
-        goto error;
-      }
-
-      // Increment the coverage for the main entry point.
-      INIT_COVERAGE();
-      COUNT_COVERAGE_MAIN();
-
-      /* Load first op and dispatch it (safe since JSOp::RetRval). */
-      ADVANCE_AND_DISPATCH(0);
-#endif  // !ENABLE_JS_INTERP_NATIVE_CALLSTACK
+      goto error;
     }
 
     CASE(OptimizeSpreadCall) {
@@ -4745,6 +4615,8 @@ initial_dispatch:
     END_CASE(AfterYield)
 
     CASE(FinalYieldRval) {
+      BAIL_IF_SPECIALIZED(InterpretEntryKind::InterpretBailout);
+
       ReservedRooted<JSObject*> gen(&ictx.rootObject0, &REGS.sp[-1].toObject());
       REGS.sp--;
       AbstractGeneratorObject::finalSuspend(gen);
@@ -5016,6 +4888,181 @@ static MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER bool InterpretInnerBailout(
   return InterpretInner(cx, state, ictx, pc, isd, entryKind);
 }
 #endif
+
+#ifdef ENABLE_JS_INTERP_WEVAL
+MOZ_NEVER_INLINE
+#else
+MOZ_ALWAYS_INLINE
+#endif
+static InterpretCallResult InterpretCall(JSContext* cx, RunState& state,
+                                         InterpretContext& ictx,
+                                         jsbytecode* pc) {
+  static_assert(JSOpLength_Call == JSOpLength_New,
+                "call and new must be the same size");
+  static_assert(JSOpLength_Call == JSOpLength_CallContent,
+                "call and call-content must be the same size");
+  static_assert(JSOpLength_Call == JSOpLength_CallIgnoresRv,
+                "call and call-ignores-rv must be the same size");
+  static_assert(JSOpLength_Call == JSOpLength_CallIter,
+                "call and calliter must be the same size");
+  static_assert(JSOpLength_Call == JSOpLength_CallContentIter,
+                "call and call-content-iter must be the same size");
+  static_assert(JSOpLength_Call == JSOpLength_SuperCall,
+                "call and supercall must be the same size");
+
+  if (REGS.fp()->hasPushedGeckoProfilerFrame()) {
+    cx->geckoProfiler().updatePC(cx, ictx.script, pc);
+  }
+
+  JSOp op = JSOp(*pc);
+  MaybeConstruct construct = MaybeConstruct(
+      op == JSOp::New || op == JSOp::NewContent || op == JSOp::SuperCall);
+  bool ignoresReturnValue = op == JSOp::CallIgnoresRv;
+  unsigned argStackSlots = GET_ARGC(pc) + construct;
+
+  MOZ_ASSERT(REGS.stackDepth() >= 2u + GET_ARGC(pc));
+  CallArgs args =
+      CallArgsFromSp(argStackSlots, REGS.sp, construct, ignoresReturnValue);
+
+  JSFunction* maybeFun;
+  bool isFunction = IsFunctionObject(args.calleev(), &maybeFun);
+
+  // Use the slow path if the callee is not an interpreted function, if we
+  // have to throw an exception, or if we might have to invoke the
+  // OnNativeCall hook for a self-hosted builtin.
+  if (!isFunction || !maybeFun->isInterpreted() ||
+      (construct && !maybeFun->isConstructor()) ||
+      (!construct && maybeFun->isClassConstructor()) ||
+      cx->insideDebuggerEvaluationWithOnNativeCallHook) {
+    if (construct) {
+      CallReason reason =
+          op == JSOp::NewContent ? CallReason::CallContent : CallReason::Call;
+      if (!ConstructFromStack(cx, args, reason)) {
+        goto error;
+      }
+    } else {
+      if ((op == JSOp::CallIter || op == JSOp::CallContentIter) &&
+          args.calleev().isPrimitive()) {
+        MOZ_ASSERT(args.length() == 0, "thisv must be on top of the stack");
+        ReportValueError(cx, JSMSG_NOT_ITERABLE, -1, args.thisv(), nullptr);
+        goto error;
+      }
+
+      CallReason reason =
+          (op == JSOp::CallContent || op == JSOp::CallContentIter)
+              ? CallReason::CallContent
+              : CallReason::Call;
+      if (!CallFromStack(cx, args, reason)) {
+        goto error;
+      }
+    }
+    Value* newsp = args.spAfterCall();
+    REGS.sp = newsp;
+    return InterpretCallResult::SuccessAdvancePastCall;
+  }
+
+  {
+    MOZ_ASSERT(maybeFun);
+    ReservedRooted<JSFunction*> fun(&ictx.rootFunction0, maybeFun);
+    ReservedRooted<JSScript*> funScript(&ictx.rootScript0,
+                                        JSFunction::getOrCreateScript(cx, fun));
+    if (!funScript) {
+      goto error;
+    }
+
+    // Enter the callee's realm if this is a cross-realm call. Use
+    // MakeScopeExit to leave this realm on all error/JIT-return paths
+    // below.
+    const bool isCrossRealm = cx->realm() != funScript->realm();
+    if (isCrossRealm) {
+      cx->enterRealmOf(funScript);
+    }
+    auto leaveRealmGuard = mozilla::MakeScopeExit([isCrossRealm, cx, &ictx] {
+      if (isCrossRealm) {
+        cx->leaveRealm(ictx.script->realm());
+      }
+    });
+
+    if (construct && !MaybeCreateThisForConstructor(cx, args)) {
+      goto error;
+    }
+
+#ifndef ENABLE_JS_INTERP_WEVAL
+    {
+      InvokeState state(cx, args, construct);
+
+      jit::EnterJitStatus status = jit::MaybeEnterJit(cx, state);
+      switch (status) {
+        case jit::EnterJitStatus::Error:
+          goto error;
+        case jit::EnterJitStatus::Ok:
+          ictx.interpReturnOK = true;
+          CHECK_BRANCH();
+          REGS.sp = args.spAfterCall();
+          goto jit_return;
+        case jit::EnterJitStatus::NotEntered:
+          break;
+      }
+
+#  ifdef NIGHTLY_BUILD
+      // If entry trampolines are enabled, call back into
+      // MaybeEnterInterpreterTrampoline so we can generate an
+      // entry trampoline for the new frame.
+      if (jit::JitOptions.emitInterpreterEntryTrampoline) {
+        if (MaybeEnterInterpreterTrampoline(cx, state)) {
+          ictx.interpReturnOK = true;
+          CHECK_BRANCH();
+          REGS.sp = args.spAfterCall();
+          goto jit_return;
+        }
+        goto error;
+      }
+#  endif  // NIGHTLY_BUILD
+    }
+#endif  // !ENABLE_JS_INTERP_WEVAL
+
+    funScript = fun->nonLazyScript();
+
+    if (!ictx.activation.pushInlineFrame(args, funScript, construct)) {
+      goto error;
+    }
+    leaveRealmGuard.release();  // We leave the callee's realm when we
+                                // call popInlineFrame.
+  }
+
+  SET_SCRIPT(REGS.fp()->script());
+
+#ifdef ENABLE_JS_INTERP_NATIVE_CALLSTACK
+  bool ret;
+  CALL_INNER(ret);
+  if (!ret) {
+    goto error;
+  }
+  return InterpretCallResult::SuccessAdvancePastCall;
+#else   // ENABLE_JS_INTERP_NATIVE_CALLSTACK
+  if (!REGS.fp()->prologue(cx)) {
+    goto prologue_error;
+  }
+
+  if (!DebugAPI::onEnterFrame(cx, REGS.fp())) {
+    goto error;
+  }
+
+  // Increment the coverage for the main entry point.
+  INIT_COVERAGE();
+  COUNT_COVERAGE_MAIN();
+  return InterpretCallResult::SuccessZeroAdvance;
+#endif  // !ENABLE_JS_INTERP_NATIVE_CALLSTACK
+
+error:
+  return InterpretCallResult::Error;
+#ifndef ENABLE_JS_INTERP_WEVAL
+prologue_error:
+  return InterpretCallResult::PrologueError;
+jit_return:
+  return InterpretCallResult::JitReturn;
+#endif
+}
 
 bool js::ThrowOperation(JSContext* cx, HandleValue v) {
   MOZ_ASSERT(!cx->isExceptionPending());

--- a/js/src/vm/Interpreter.h
+++ b/js/src/vm/Interpreter.h
@@ -206,6 +206,15 @@ extern bool ExecuteKernel(JSContext* cx, HandleScript script,
 extern bool Execute(JSContext* cx, HandleScript script, HandleObject envChain,
                     MutableHandleValue rval);
 
+#ifdef ENABLE_JS_INTERP_WEVAL
+
+#  include <weval.h>  // weval_req_t
+
+extern weval_req_t* RegisterInterpreterSpecialization(void** specialized,
+                                                      ImmutableScriptData* isd,
+                                                      jsbytecode* pc);
+#endif  // ENABLE_JS_INTERP_WEVAL
+
 class ExecuteState;
 class InvokeState;
 

--- a/js/src/vm/SharedStencil-inl.h
+++ b/js/src/vm/SharedStencil-inl.h
@@ -1,0 +1,37 @@
+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+ * vim: set ts=8 sts=2 et sw=2 tw=80:
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef vm_SharedStencil_inl_h
+#define vm_SharedStencil_inl_h
+
+#include "vm/SharedStencil.h"
+
+#include "vm/BytecodeUtil.h"  // GET_RESUMEINDEX, JUMP_OFFSET_LEN
+
+namespace js {
+
+MOZ_ALWAYS_INLINE
+uint32_t ImmutableScriptData::tableSwitchCaseOffset(jsbytecode* pc,
+                                                    uint32_t caseIndex) {
+  MOZ_ASSERT(JSOp(*pc) == JSOp::TableSwitch);
+  uint32_t firstResumeIndex = GET_RESUMEINDEX(pc + 3 * JUMP_OFFSET_LEN);
+  return resumeOffsets()[firstResumeIndex + caseIndex];
+}
+jsbytecode* ImmutableScriptData::tableSwitchCasePC(jsbytecode* pc,
+                                                   uint32_t caseIndex) {
+  return offsetToPC(tableSwitchCaseOffset(pc, caseIndex));
+}
+jsbytecode* ImmutableScriptData::offsetToPC(size_t offset) {
+  return code() + offset;
+}
+
+size_t ImmutableScriptData::pcToOffset(const jsbytecode* pc) {
+  return size_t(pc - code());
+}
+
+}  // namespace js
+
+#endif /* vm_SharedStencil_inl_h */

--- a/js/src/vm/SharedStencil.h
+++ b/js/src/vm/SharedStencil.h
@@ -671,6 +671,9 @@ class alignas(uint32_t) ImmutableScriptData final : public TrailingArray {
   // ImmutableScriptData has trailing data so isn't copyable or movable.
   ImmutableScriptData(const ImmutableScriptData&) = delete;
   ImmutableScriptData& operator=(const ImmutableScriptData&) = delete;
+
+ private:
+  bool RequestSpecialization(FrontendContext* fc);
 };
 
 // Wrapper type for ImmutableScriptData to allow sharing across a JSRuntime.

--- a/js/src/vm/SharedStencil.h
+++ b/js/src/vm/SharedStencil.h
@@ -31,6 +31,10 @@
 #include "vm/GeneratorAndAsyncKind.h"  // GeneratorKind, FunctionAsyncKind
 #include "vm/StencilEnums.h"  // js::{TryNoteKind,ImmutableScriptFlagsEnum,MutableScriptFlagsEnum}
 
+#ifdef ENABLE_JS_INTERP_WEVAL
+#  include <weval.h>
+#endif
+
 //
 // Data structures shared between Stencil and the VM.
 //
@@ -422,6 +426,18 @@ class MutableScriptFlags : public EnumFlags<MutableScriptFlagsEnum> {
 // notable exception is that bytecode length is stored explicitly.
 class alignas(uint32_t) ImmutableScriptData final : public TrailingArray {
  private:
+#ifdef ENABLE_JS_INTERP_WEVAL
+  // Partially-pecialized interpreter body, if any. Note that we need
+  // to box this so that it doesn't move. This pointer comes first so
+  // we can exclide it from hashing.
+  void** specialized_ = nullptr;
+
+  // The weval specialization request, so that we may cancel it if
+  // this script is freed.
+  weval_req_t* weval_req_ = nullptr;
+#endif
+
+ private:
   Offset optArrayOffset_ = 0;
 
   // Length of bytecode
@@ -567,8 +583,15 @@ class alignas(uint32_t) ImmutableScriptData final : public TrailingArray {
 
   // Span over all raw bytes in this struct and its trailing arrays.
   mozilla::Span<const uint8_t> immutableData() const {
-    size_t allocSize = endOffset();
-    return mozilla::Span{reinterpret_cast<const uint8_t*>(this), allocSize};
+#ifdef ENABLE_JS_INTERP_WEVAL
+    size_t specializedSize = sizeof(void**) + sizeof(weval_req_t*);
+#else
+    size_t specializedSize = 0;
+#endif
+    size_t allocSize = endOffset() - specializedSize;
+    return mozilla::Span{
+        reinterpret_cast<const uint8_t*>(this) + specializedSize,
+        allocSize - specializedSize};
   }
 
  private:
@@ -622,6 +645,24 @@ class alignas(uint32_t) ImmutableScriptData final : public TrailingArray {
     return offsetof(ImmutableScriptData, funLength);
   }
 
+#ifdef ENABLE_JS_INTERP_WEVAL
+  void* specializedCode() {
+    if (specialized_) {
+      return *specialized_;
+    }
+    return nullptr;
+  }
+
+  weval_req_t* wevalReq() { return weval_req_; }
+
+  void releaseWevalState() {
+    if (weval_req_) {
+      weval::free(weval_req_);
+    }
+    js_delete(specialized_);
+  }
+#endif
+
   uint32_t tableSwitchCaseOffset(jsbytecode* pc, uint32_t caseIndex);
   jsbytecode* tableSwitchCasePC(jsbytecode* pc, uint32_t caseIndex);
   jsbytecode* offsetToPC(size_t offset);
@@ -671,6 +712,9 @@ class SharedImmutableScriptData {
 
   void reset() {
     if (isd_ && !isExternal()) {
+#ifdef ENABLE_JS_INTERP_WEVAL
+      isd_->releaseWevalState();
+#endif
       js_delete(isd_);
     }
     isd_ = nullptr;

--- a/js/src/vm/SharedStencil.h
+++ b/js/src/vm/SharedStencil.h
@@ -622,6 +622,11 @@ class alignas(uint32_t) ImmutableScriptData final : public TrailingArray {
     return offsetof(ImmutableScriptData, funLength);
   }
 
+  uint32_t tableSwitchCaseOffset(jsbytecode* pc, uint32_t caseIndex);
+  jsbytecode* tableSwitchCasePC(jsbytecode* pc, uint32_t caseIndex);
+  jsbytecode* offsetToPC(size_t offset);
+  size_t pcToOffset(const jsbytecode* pc);
+
   // ImmutableScriptData has trailing data so isn't copyable or movable.
   ImmutableScriptData(const ImmutableScriptData&) = delete;
   ImmutableScriptData& operator=(const ImmutableScriptData&) = delete;

--- a/js/src/vm/Stack.h
+++ b/js/src/vm/Stack.h
@@ -790,8 +790,13 @@ class InterpreterStack {
   LifoAlloc allocator_;
 
   // Number of interpreter frames on the stack, for over-recursion checks.
+#ifndef ENABLE_JS_INTERP_NATIVE_CALLSTACK
   static const size_t MAX_FRAMES = 50 * 1000;
   static const size_t MAX_FRAMES_TRUSTED = MAX_FRAMES + 1000;
+#else
+  static const size_t MAX_FRAMES = 5 * 1000;
+  static const size_t MAX_FRAMES_TRUSTED = MAX_FRAMES + 1000;
+#endif
   size_t frameCount_;
 
   inline uint8_t* allocateFrame(JSContext* cx, size_t size);

--- a/js/src/wasm/moz.build
+++ b/js/src/wasm/moz.build
@@ -64,3 +64,7 @@ if CONFIG["OS_ARCH"] != "WASI":
 # coverage instrumentation in FUZZING mode.
 if CONFIG["FUZZING_INTERFACES"] and CONFIG["LIBFUZZER"]:
     include("/tools/fuzzing/libfuzzer-config.mozbuild")
+
+LOCAL_INCLUDES += [
+    "/third_party/weval",
+]

--- a/third_party/weval/weval.h
+++ b/third_party/weval/weval.h
@@ -1,0 +1,301 @@
+#pragma once
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ------------------------------------------------------------------------- */
+/* partial-evaluation async requests and queues                              */
+/* ------------------------------------------------------------------------- */
+
+typedef void (*weval_func_t)();
+
+typedef struct weval_req_t weval_req_t;
+typedef struct weval_req_arg_t weval_req_arg_t;
+
+struct weval_req_t {
+  weval_req_t* next;
+  weval_req_t* prev;
+  weval_func_t func;
+  weval_req_arg_t* args;
+  uint32_t nargs;
+  weval_func_t* specialized;
+};
+
+typedef enum {
+  weval_req_arg_i32 = 0,
+  weval_req_arg_i64 = 1,
+  weval_req_arg_f32 = 2,
+  weval_req_arg_f64 = 3,
+} weval_req_arg_type;
+
+struct weval_req_arg_t {
+  uint32_t specialize;
+  uint32_t ty;
+  union {
+    uint32_t i32;
+    uint64_t i64;
+    float f32;
+    double f64;
+  } u;
+};
+
+extern weval_req_t* weval_req_pending_head;
+
+#define WEVAL_DEFINE_REQ_LIST()                                    \
+  weval_req_t* weval_req_pending_head;                             \
+  __attribute__((export_name("weval.pending.head"))) weval_req_t** \
+  __weval_pending_head() {                                         \
+    return &weval_req_pending_head;                                \
+  }
+
+static inline void weval_request(weval_req_t* req) {
+  req->next = weval_req_pending_head;
+  req->prev = NULL;
+  if (weval_req_pending_head) {
+    weval_req_pending_head->prev = req;
+  }
+  weval_req_pending_head = req;
+}
+
+static inline void weval_free(weval_req_t* req) {
+  if (req->prev) {
+    req->prev->next = req->next;
+  } else if (weval_req_pending_head == req) {
+    weval_req_pending_head = req->next;
+  }
+  if (req->next) {
+    req->next->prev = req->prev;
+  }
+  if (req->args) {
+    free(req->args);
+  }
+  free(req);
+}
+
+/* ------------------------------------------------------------------------- */
+/* intrinsics                                                                */
+/* ------------------------------------------------------------------------- */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define WEVAL_WASM_IMPORT(name) \
+  __attribute__((__import_module__("weval"), __import_name__(name)))
+
+const void* weval_assume_const_memory(const void* p)
+    WEVAL_WASM_IMPORT("assume.const.memory");
+const void* weval_assume_const_memory_transitive(const void* p)
+    WEVAL_WASM_IMPORT("assume.const.memory.transitive");
+void weval_push_context(uint32_t pc) WEVAL_WASM_IMPORT("push.context");
+void weval_pop_context() WEVAL_WASM_IMPORT("pop.context");
+void weval_update_context(uint32_t pc) WEVAL_WASM_IMPORT("update.context");
+void* weval_make_symbolic_ptr(void* p) WEVAL_WASM_IMPORT("make.symbolic.ptr");
+void weval_flush_to_mem() WEVAL_WASM_IMPORT("flush.to.mem");
+void weval_trace_line(uint32_t line_number) WEVAL_WASM_IMPORT("trace.line");
+void weval_abort_specialization(uint32_t line_number, uint32_t fatal)
+    WEVAL_WASM_IMPORT("abort.specialization");
+void weval_assert_const32(uint32_t value, uint32_t line_no)
+    WEVAL_WASM_IMPORT("assert.const32");
+void weval_assert_const_memory(void* p, uint32_t line_no)
+    WEVAL_WASM_IMPORT("assert.const.memory");
+uint32_t weval_specialize_value(uint32_t value, uint32_t lo, uint32_t hi)
+    WEVAL_WASM_IMPORT("specialize.value");
+void weval_print(const char* message, uint32_t line, uint32_t val)
+    WEVAL_WASM_IMPORT("print");
+
+void weval_context_bucket(uint32_t bucket) WEVAL_WASM_IMPORT("context.bucket");
+
+#undef WEVAL_WASM_IMPORT
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#ifdef __cplusplus
+namespace weval {
+template <typename T>
+const T* assume_const_memory(const T* t) {
+  return (const T*)weval_assume_const_memory((const void*)t);
+}
+template <typename T>
+T* assume_const_memory(T* t) {
+  return (T*)weval_assume_const_memory((void*)t);
+}
+template <typename T>
+const T* assume_const_memory_transitive(const T* t) {
+  return (const T*)weval_assume_const_memory_transitive((const void*)t);
+}
+template <typename T>
+T* assume_const_memory_transitive(T* t) {
+  return (T*)weval_assume_const_memory_transitive((void*)t);
+}
+
+static inline void push_context(uint32_t pc) { weval_push_context(pc); }
+
+static inline void pop_context() { weval_pop_context(); }
+
+static inline void update_context(uint32_t pc) { weval_update_context(pc); }
+template <typename T>
+static T* make_symbolic_ptr(T* t) {
+  return (T*)weval_make_symbolic_ptr((void*)t);
+}
+template <typename T>
+void flush_to_mem() {
+  weval_flush_to_mem();
+}
+
+}  // namespace weval
+#endif  // __cplusplus
+
+/* ------------------------------------------------------------------------- */
+/* C++ type-safe wrapper for partial evaluation of functions                 */
+/* ------------------------------------------------------------------------- */
+
+#ifdef __cplusplus
+namespace weval {
+
+template <typename T>
+struct ArgSpec {};
+
+template <typename T>
+struct RuntimeArg : ArgSpec<T> {};
+
+template <typename T>
+RuntimeArg<T> Runtime() {
+  return RuntimeArg<T>{};
+}
+
+template <typename T>
+struct Specialize : ArgSpec<T> {
+  T value;
+  explicit Specialize(T value_) : value(value_) {}
+};
+
+namespace impl {
+template <typename Ret, typename... Args>
+using FuncPtr = Ret (*)(Args...);
+
+template <typename T>
+struct StoreArg;
+
+template <>
+struct StoreArg<uint32_t> {
+  void operator()(weval_req_arg_t* arg, uint32_t value) {
+    arg->specialize = 1;
+    arg->ty = weval_req_arg_i32;
+    arg->u.i32 = value;
+  }
+};
+template <>
+struct StoreArg<bool> {
+  void operator()(weval_req_arg_t* arg, bool value) {
+    arg->specialize = 1;
+    arg->ty = weval_req_arg_i32;
+    arg->u.i32 = value ? 1 : 0;
+  }
+};
+template <>
+struct StoreArg<uint64_t> {
+  void operator()(weval_req_arg_t* arg, uint64_t value) {
+    arg->specialize = 1;
+    arg->ty = weval_req_arg_i64;
+    arg->u.i64 = value;
+  }
+};
+template <>
+struct StoreArg<float> {
+  void operator()(weval_req_arg_t* arg, float value) {
+    arg->specialize = 1;
+    arg->ty = weval_req_arg_f32;
+    arg->u.f32 = value;
+  }
+};
+template <>
+struct StoreArg<double> {
+  void operator()(weval_req_arg_t* arg, double value) {
+    arg->specialize = 1;
+    arg->ty = weval_req_arg_f64;
+    arg->u.f64 = value;
+  }
+};
+template <typename T>
+struct StoreArg<T*> {
+  void operator()(weval_req_arg_t* arg, T* value) {
+    static_assert(sizeof(T*) == 4, "Only 32-bit Wasm supported");
+    arg->specialize = 1;
+    arg->ty = weval_req_arg_i32;
+    arg->u.i32 = reinterpret_cast<uint32_t>(value);
+  }
+};
+template <typename T>
+struct StoreArg<T&> {
+  void operator()(weval_req_arg_t* arg, T& value) { StoreArg<T*>(arg, &value); }
+};
+template <typename T>
+struct StoreArg<const T*> {
+  void operator()(weval_req_arg_t* arg, const T* value) {
+    static_assert(sizeof(const T*) == 4, "Only 32-bit Wasm supported");
+    arg->specialize = 1;
+    arg->ty = weval_req_arg_i32;
+    arg->u.i32 = reinterpret_cast<uint32_t>(value);
+  }
+};
+
+template <typename... Args>
+struct StoreArgs {};
+
+template <>
+struct StoreArgs<> {
+  void operator()(weval_req_arg_t* args) {}
+};
+
+template <typename T, typename... Rest>
+struct StoreArgs<Specialize<T>, Rest...> {
+  void operator()(weval_req_arg_t* args, Specialize<T> arg0, Rest... rest) {
+    StoreArg<T>()(args, arg0.value);
+    StoreArgs<Rest...>()(args + 1, rest...);
+  }
+};
+
+template <typename T, typename... Rest>
+struct StoreArgs<RuntimeArg<T>, Rest...> {
+  void operator()(weval_req_arg_t* args, RuntimeArg<T> arg0, Rest... rest) {
+    args[0].specialize = 0;
+    StoreArgs<Rest...>()(args + 1, rest...);
+  }
+};
+
+}  // namespace impl
+
+template <typename Ret, typename... Args, typename... WrappedArgs>
+weval_req_t* weval(impl::FuncPtr<Ret, Args...>* dest,
+                   impl::FuncPtr<Ret, Args...> generic, WrappedArgs... args) {
+  weval_req_t* req = (weval_req_t*)malloc(sizeof(weval_req_t));
+  if (!req) {
+    return nullptr;
+  }
+  uint32_t nargs = sizeof...(Args);
+  weval_req_arg_t* arg_storage =
+      (weval_req_arg_t*)malloc(sizeof(weval_req_arg_t) * nargs);
+  if (!arg_storage) {
+    return nullptr;
+  }
+  impl::StoreArgs<WrappedArgs...>()(arg_storage, args...);
+
+  req->func = (weval_func_t)generic;
+  req->args = arg_storage;
+  req->nargs = nargs;
+  req->specialized = (weval_func_t*)dest;
+
+  weval_request(req);
+
+  return req;
+}
+
+inline void free(weval_req_t* req) { weval_free(req); }
+
+}  // namespace weval
+
+#endif  // __cplusplus


### PR DESCRIPTION
This PR merges the under-review SpiderMonkey-side annotations and refactors for use with the [weval](https://github.com/cfallin/weval) partial-evaluation tool. This tool and these changes together can produce speedups on various workloads by generating compiled function bodies that replace the interpreter for ahead-of-time-known functions.

The work is tracked in Mozilla's Bugzilla under [meta-bug 1831399](https://bugzilla.mozilla.org/show_bug.cgi?id=1831399), with patches for review in [bug 1831676](https://bugzilla.mozilla.org/show_bug.cgi?id=1831676) and [bug 1832406](https://bugzilla.mozilla.org/show_bug.cgi?id=1832406). This PR has exactly that patch sequence, cherry-picked onto `fastly/js-compute-runtime-ff-112`. The intent is to carry these locally and pull this version of the engine into our embedding/SDK until they can be upstreamed.

These patches do not add any intrinsics or other special behavior unless explicitly enabled with `--enable-js-interp-native-callstack --enable-js-interp-specialization --enable-js-interp-weval`. Otherwise, the refactors move some things around (e.g. discrete local vars put into a struct) but nothing that should have any impact. In our use-case, we will plan to have one build with these flags and one without, and use the engine build with weval intrinsics only when the weval pass is run.