### PR TITLE
Avoid misaligned jitcode pointer under PBL on wasm.

### DIFF
--- a/js/src/vm/JSScript.cpp
+++ b/js/src/vm/JSScript.cpp
@@ -3183,6 +3183,12 @@ BaseScript* BaseScript::CreateRawLazy(JSContext* cx, uint32_t ngcthings,
   return lazy;
 }
 
+// This is an arbitrary non-null pointer that we use as a placeholder
+// for scripts that can be run in PBL: the rest of the engine expects
+// a "non-null jitcode pointer" but we'll never actually call it. We
+// have to ensure alignment to keep GC happy.
+static uint8_t* const PBLJitCodePtr = reinterpret_cast<uint8_t*>(8);
+
 void JSScript::updateJitCodeRaw(JSRuntime* rt) {
   MOZ_ASSERT(rt);
   if (hasBaselineScript() && baselineScript()->hasPendingIonCompileTask()) {
@@ -3210,8 +3216,8 @@ void JSScript::updateJitCodeRaw(JSRuntime* rt) {
              js::jit::IsPortableBaselineInterpreterEnabled()) {
     // The portable baseline interpreter does not dispatch on this
     // pointer, but it needs to be non-null to trigger the appropriate
-    // code-paths, so we set it to the entry trampoline itself here.
-    setJitCodeRaw(reinterpret_cast<uint8_t*>(&js::PortableBaselineTrampoline));
+    // code-paths, so we set it to a placeholder value here.
+    setJitCodeRaw(PBLJitCodePtr);
 #endif  // ENABLE_PORTABLE_BASELINE_INTERP
   } else if (!js::jit::IsBaselineInterpreterEnabled()) {
     setJitCodeRaw(nullptr);


### PR DESCRIPTION
The PBL tier fills the jitcode pointer on `JSScript`s with an arbitrary non-null value. This is required because other tiering code uses this null-check to determine whether it is possible to invoke any higher tiers (on native platforms, it is set even for baseline interp, to blinterp's entrypoint). We don't ever actually invoke the code pointer under PBL, so instead we arbitrarily set it to the function pointer for PBL's entry point.

The jitcode pointer is stored in the JSScript's cell header, which requires the low few bits to be clear (they are set when the cell forwards to another cell after a moving GC pass). On native platforms function pointers are usually aligned as required, but on wasm32 they are indices into a table and can have arbitrary values. So instead, we use a constant value `8` to satisfy the constraint of "arbitrary non-null value".