### PR TITLE
Undo a change from 89826427d5, fixing a small perf regression on native.

### DIFF
--- a/js/src/vm/PortableBaselineInterpret.cpp
+++ b/js/src/vm/PortableBaselineInterpret.cpp
@@ -5296,13 +5296,11 @@ unwind_ret:
 debug : {
   TRACE_PRINTF("hit debug point\n");
   PUSH_EXIT_FRAME();
-  if (DebugAPI::hasAnyBreakpointsOrStepMode(script)) {
-    if (!HandleDebugTrap(cx, frame, pc)) {
-      TRACE_PRINTF("HandleDebugTrap returned error\n");
-      goto error;
-    }
-    pc = frame->interpreterPC();
+  if (!HandleDebugTrap(cx, frame, pc)) {
+    TRACE_PRINTF("HandleDebugTrap returned error\n");
+    goto error;
   }
+  pc = frame->interpreterPC();
   TRACE_PRINTF("HandleDebugTrap done\n");
 }
   goto dispatch;


### PR DESCRIPTION
The extra conditional doesn't actually seem to be necessary for all tests to pass even on a debug build. IIRC I had originally added it because the AfterYield debug hook invocations were not quite right with respect to an assert, but harmless (one extra call when breakpoints weren't actually enabled, or something like that); but this doesn't seem to happen anymore.

For somewhat perplexing reasons, altering this codepath makes a ~6% performance improvement on native on Octane's Richards benchmark (my arbitrarily picked test case for a recent regression), even though the code path never executes. Perhaps it affects other optimizations.