### PR TITLE
PBL: add option to force use of the PBL tier.

### DIFF
--- a/js/moz.configure
+++ b/js/moz.configure
@@ -201,6 +201,17 @@ option(
 set_define("ENABLE_PORTABLE_BASELINE_INTERP", depends_if("--enable-portable-baseline-interp")(lambda _: True))
 set_config("ENABLE_PORTABLE_BASELINE_INTERP", depends_if("--enable-portable-baseline-interp")(lambda _: True))
 
+# Option to always force PBL tier.
+option(
+    "--enable-portable-baseline-interp-force",
+    default=False,
+    help="{Enable|Disable} forcing use of the portable baseline interpreter.",
+)
+
+set_define("ENABLE_PORTABLE_BASELINE_INTERP_FORCE", depends_if("--enable-portable-baseline-interp-force")(lambda _: True))
+set_config("ENABLE_PORTABLE_BASELINE_INTERP_FORCE", depends_if("--enable-portable-baseline-interp-force")(lambda _: True))
+
+
 # JIT support
 # =======================================================
 @depends(target, "--enable-record-tuple", "--enable-portable-baseline-interp")

--- a/js/src/jit/JitOptions.cpp
+++ b/js/src/jit/JitOptions.cpp
@@ -134,6 +134,11 @@ DefaultJitOptions::DefaultJitOptions() {
   SET_DEFAULT(portableBaselineInterpreter, false);
 #endif
 
+#ifdef ENABLE_PORTABLE_BASELINE_INTERP_FORCE
+  SET_DEFAULT(portableBaselineInterpreter, true);
+  SET_DEFAULT(portableBaselineInterpreterWarmUpThreshold, 0);
+#endif
+
   // Emit baseline interpreter and interpreter entry frames to distinguish which
   // JSScript is being interpreted by external profilers.
   // Enabled by default under --enable-perf, otherwise disabled.


### PR DESCRIPTION
This allows us to avoid the need for JS shell options and makes testing of this configuration slightly easier.