### PR TITLE
PBL: fix [Strict]SetElemSuper stack signature.

### DIFF
--- a/js/src/vm/PortableBaselineInterpret.cpp
+++ b/js/src/vm/PortableBaselineInterpret.cpp
@@ -3682,7 +3682,7 @@ static PBIResult PortableBaselineInterpret(JSContext* cx_, State& state,
             goto error;
           }
         }
-        PUSH(StackVal(value2));  // value
+        PUSH(StackVal(value3));  // value
       }
       END_OP(SetElemSuper);
     }


### PR DESCRIPTION
SetElemSuper and StrictSetElemSuper are supposed to leave `val` on the stack; this is the fourth input arg, not third. This was probably a copy-paste-o from another opcode impl in the SetProp family.

With this and #17, all jstests should now pass.