### PR TITLE
3 more patches needed to carry for wasi builds of spidermonkey

### DIFF
--- a/js/public/Printer.h
+++ b/js/public/Printer.h
@@ -81,10 +81,6 @@
 //    `exportInto` to serialize its content to a Sprinter or a Fprinter. This is
 //    useful to avoid reallocation copies, while using an existing LifoAlloc.
 //
-//  - SEPrinter: Roughly the same as Fprinter for stderr, except it goes through
-//    printf_stderr, which makes sure the output goes to a useful place: the
-//    Android log or the Windows debug output.
-//
 //  - EscapePrinter: Wrapper around other printers, to escape characters when
 //    necessary.
 //

--- a/js/src/builtin/Array.cpp
+++ b/js/src/builtin/Array.cpp
@@ -10,7 +10,6 @@
 #include "mozilla/DebugOnly.h"
 #include "mozilla/MathAlgorithms.h"
 #include "mozilla/Maybe.h"
-#include "mozilla/SIMD.h"
 #include "mozilla/TextUtils.h"
 
 #include <algorithm>
@@ -64,7 +63,6 @@ using mozilla::CheckedInt;
 using mozilla::DebugOnly;
 using mozilla::IsAsciiDigit;
 using mozilla::Maybe;
-using mozilla::SIMD;
 
 using JS::AutoCheckCannotGC;
 using JS::IsArrayAnswer;
@@ -4232,19 +4230,6 @@ bool js::array_indexOf(JSContext* cx, unsigned argc, Value* vp) {
         std::min(nobj->getDenseInitializedLength(), uint32_t(len));
     const Value* elements = nobj->getDenseElements();
 
-    if (CanUseBitwiseCompareForStrictlyEqual(searchElement) && length > start) {
-      const uint64_t* elementsAsBits =
-          reinterpret_cast<const uint64_t*>(elements);
-      const uint64_t* res = SIMD::memchr64(
-          elementsAsBits + start, searchElement.asRawBits(), length - start);
-      if (res) {
-        args.rval().setInt32(static_cast<int32_t>(res - elementsAsBits));
-      } else {
-        args.rval().setInt32(-1);
-      }
-      return true;
-    }
-
     auto iterator = [elements, start, length](JSContext* cx, auto cmp,
                                               MutableHandleValue rval) {
       static_assert(NativeObject::MAX_DENSE_ELEMENTS_COUNT <= INT32_MAX,
@@ -4476,19 +4461,6 @@ bool js::array_includes(JSContext* cx, unsigned argc, Value* vp) {
     if (uint32_t(len) > length && searchElement.isUndefined()) {
       // |undefined| is strictly equal only to |undefined|.
       args.rval().setBoolean(true);
-      return true;
-    }
-
-    // For |includes| we need to treat hole values as |undefined| so we use a
-    // different path if searching for |undefined|.
-    if (CanUseBitwiseCompareForStrictlyEqual(searchElement) &&
-        !searchElement.isUndefined() && length > start) {
-      if (SIMD::memchr64(reinterpret_cast<const uint64_t*>(elements) + start,
-                         searchElement.asRawBits(), length - start)) {
-        args.rval().setBoolean(true);
-      } else {
-        args.rval().setBoolean(false);
-      }
       return true;
     }
 

--- a/js/src/builtin/String.cpp
+++ b/js/src/builtin/String.cpp
@@ -15,7 +15,6 @@
 #endif
 #include "mozilla/PodOperations.h"
 #include "mozilla/Range.h"
-#include "mozilla/SIMD.h"
 #include "mozilla/TextUtils.h"
 
 #include <algorithm>
@@ -70,7 +69,6 @@ using mozilla::EnsureUtf16ValiditySpan;
 using mozilla::IsAsciiHexDigit;
 using mozilla::PodCopy;
 using mozilla::RangedPtr;
-using mozilla::SIMD;
 using mozilla::Span;
 using mozilla::Utf16ValidUpTo;
 
@@ -1904,7 +1902,7 @@ struct MemCmp {
   using Extent = uint32_t;
   static MOZ_ALWAYS_INLINE Extent computeExtent(const PatChar*,
                                                 uint32_t patLen) {
-    return (patLen - 2) * sizeof(PatChar);
+    return (patLen - 1) * sizeof(PatChar);
   }
   static MOZ_ALWAYS_INLINE bool match(const PatChar* p, const TextChar* t,
                                       Extent extent) {
@@ -1931,35 +1929,78 @@ struct ManualCmp {
   }
 };
 
+template <typename TextChar, typename PatChar>
+static const TextChar* FirstCharMatcherUnrolled(const TextChar* text,
+                                                uint32_t n, const PatChar pat) {
+  const TextChar* textend = text + n;
+  const TextChar* t = text;
+
+  switch ((textend - t) & 7) {
+    case 0:
+      if (*t++ == pat) return t - 1;
+      [[fallthrough]];
+    case 7:
+      if (*t++ == pat) return t - 1;
+      [[fallthrough]];
+    case 6:
+      if (*t++ == pat) return t - 1;
+      [[fallthrough]];
+    case 5:
+      if (*t++ == pat) return t - 1;
+      [[fallthrough]];
+    case 4:
+      if (*t++ == pat) return t - 1;
+      [[fallthrough]];
+    case 3:
+      if (*t++ == pat) return t - 1;
+      [[fallthrough]];
+    case 2:
+      if (*t++ == pat) return t - 1;
+      [[fallthrough]];
+    case 1:
+      if (*t++ == pat) return t - 1;
+  }
+  while (textend != t) {
+    if (t[0] == pat) return t;
+    if (t[1] == pat) return t + 1;
+    if (t[2] == pat) return t + 2;
+    if (t[3] == pat) return t + 3;
+    if (t[4] == pat) return t + 4;
+    if (t[5] == pat) return t + 5;
+    if (t[6] == pat) return t + 6;
+    if (t[7] == pat) return t + 7;
+    t += 8;
+  }
+  return nullptr;
+}
+
+static const char* FirstCharMatcher8bit(const char* text, uint32_t n,
+                                        const char pat) {
+  return reinterpret_cast<const char*>(memchr(text, pat, n));
+}
+
 template <class InnerMatch, typename TextChar, typename PatChar>
 static int Matcher(const TextChar* text, uint32_t textlen, const PatChar* pat,
                    uint32_t patlen) {
-  MOZ_ASSERT(patlen > 1);
+  MOZ_ASSERT(patlen > 0);
+
+  if (sizeof(TextChar) == 1 && sizeof(PatChar) > 1 && pat[0] > 0xff) {
+    return -1;
+  }
 
   const typename InnerMatch::Extent extent =
       InnerMatch::computeExtent(pat, patlen);
 
   uint32_t i = 0;
   uint32_t n = textlen - patlen + 1;
-
   while (i < n) {
     const TextChar* pos;
 
-    // This is a bit awkward. Consider the case where we're searching "abcdef"
-    // for "def". n will be 4, because we know in advance that the last place we
-    // can *start* a successful search will be at 'd'. However, if we just use n
-    // - i, then our first search will be looking through "abcd" for "de",
-    // because our memchr2xN functions search for two characters at a time. So
-    // we just have to compensate by adding 1. This will never exceed textlen
-    // because we know patlen is at least two.
-    size_t searchLen = n - i + 1;
     if (sizeof(TextChar) == 1) {
       MOZ_ASSERT(pat[0] <= 0xff);
-      pos = (TextChar*)SIMD::memchr2x8((char*)text + i, pat[0], pat[1],
-                                       searchLen);
+      pos = (TextChar*)FirstCharMatcher8bit((char*)text + i, n - i, pat[0]);
     } else {
-      pos = (TextChar*)SIMD::memchr2x16((char16_t*)(text + i), char16_t(pat[0]),
-                                        char16_t(pat[1]), searchLen);
+      pos = FirstCharMatcherUnrolled(text + i, n - i, char16_t(pat[0]));
     }
 
     if (pos == nullptr) {
@@ -1967,9 +2008,7 @@ static int Matcher(const TextChar* text, uint32_t textlen, const PatChar* pat,
     }
 
     i = static_cast<uint32_t>(pos - text);
-    const uint32_t inlineLookaheadChars = 2;
-    if (InnerMatch::match(pat + inlineLookaheadChars,
-                          text + i + inlineLookaheadChars, extent)) {
+    if (InnerMatch::match(pat + 1, text + i + 1, extent)) {
       return i;
     }
 
@@ -1988,26 +2027,22 @@ static MOZ_ALWAYS_INLINE int StringMatch(const TextChar* text, uint32_t textLen,
     return -1;
   }
 
-  if (sizeof(TextChar) == 1 && sizeof(PatChar) > 1 && pat[0] > 0xff) {
+#if defined(__i386__) || defined(_M_IX86) || defined(__i386)
+  /*
+   * Given enough registers, the unrolled loop below is faster than the
+   * following loop. 32-bit x86 does not have enough registers.
+   */
+  if (patLen == 1) {
+    const PatChar p0 = *pat;
+    const TextChar* end = text + textLen;
+    for (const TextChar* c = text; c != end; ++c) {
+      if (*c == p0) {
+        return c - text;
+      }
+    }
     return -1;
   }
-
-  if (patLen == 1) {
-    const TextChar* pos;
-    if (sizeof(TextChar) == 1) {
-      MOZ_ASSERT(pat[0] <= 0xff);
-      pos = (TextChar*)SIMD::memchr8((char*)text, pat[0], textLen);
-    } else {
-      pos =
-          (TextChar*)SIMD::memchr16((char16_t*)text, char16_t(pat[0]), textLen);
-    }
-
-    if (pos == nullptr) {
-      return -1;
-    }
-
-    return pos - text;
-  }
+#endif
 
   // We use a fast two-character-wide search in Matcher below, so we need to
   // validate that pat[1] isn't outside the latin1 range up front if the

--- a/js/src/gc/Marking.cpp
+++ b/js/src/gc/Marking.cpp
@@ -231,7 +231,7 @@ template void CheckTracedThing<wasm::AnyRef>(JSTracer*, const wasm::AnyRef&);
 #endif
 
 static inline bool ShouldMarkCrossCompartment(GCMarker* marker, JSObject* src,
-                                              Cell* dstCell, const char* name) {
+                                              Cell* dstCell) {
   MarkColor color = marker->markColor();
 
   if (!dstCell->isTenured()) {
@@ -239,15 +239,13 @@ static inline bool ShouldMarkCrossCompartment(GCMarker* marker, JSObject* src,
     // Bug 1743098: This shouldn't be possible but it does seem to happen. Log
     // some useful information in debug builds.
     if (color != MarkColor::Black) {
-      SEprinter printer;
-      printer.printf(
-          "ShouldMarkCrossCompartment: cross compartment edge '%s' from gray "
-          "object to nursery thing\n",
-          name);
-      printer.put("src: ");
-      src->dump(printer);
-      printer.put("dst: ");
-      dstCell->dump(printer);
+      fprintf(stderr,
+              "ShouldMarkCrossCompartment: cross compartment edge from gray "
+              "object to nursery thing\n");
+      fprintf(stderr, "src: ");
+      src->dump();
+      fprintf(stderr, "dst: ");
+      dstCell->dump();
     }
 #endif
     MOZ_ASSERT(color == MarkColor::Black);
@@ -311,19 +309,18 @@ static inline bool ShouldMarkCrossCompartment(GCMarker* marker, JSObject* src,
 }
 
 static bool ShouldTraceCrossCompartment(JSTracer* trc, JSObject* src,
-                                        Cell* dstCell, const char* name) {
+                                        Cell* dstCell) {
   if (!trc->isMarkingTracer()) {
     return true;
   }
 
-  return ShouldMarkCrossCompartment(GCMarker::fromTracer(trc), src, dstCell,
-                                    name);
+  return ShouldMarkCrossCompartment(GCMarker::fromTracer(trc), src, dstCell);
 }
 
 static bool ShouldTraceCrossCompartment(JSTracer* trc, JSObject* src,
-                                        const Value& val, const char* name) {
+                                        const Value& val) {
   return val.isGCThing() &&
-         ShouldTraceCrossCompartment(trc, src, val.toGCThing(), name);
+         ShouldTraceCrossCompartment(trc, src, val.toGCThing());
 }
 
 #ifdef DEBUG
@@ -489,7 +486,7 @@ void js::TraceManuallyBarrieredCrossCompartmentEdge(JSTracer* trc,
   // Clear expected compartment for cross-compartment edge.
   AutoClearTracingSource acts(trc);
 
-  if (ShouldTraceCrossCompartment(trc, src, *dst, name)) {
+  if (ShouldTraceCrossCompartment(trc, src, *dst)) {
     TraceEdgeInternal(trc, dst, name);
   }
 }


### PR DESCRIPTION
Without these patches, when building Fastly's JS Compute Runtime, the below errors are generated:
```
wasm-ld: error: ./js-compute-runtime/runtime/spidermonkey/debug/lib/libjs_static.a(Unified_cpp_js_src0.o): undefined symbol: mozilla::SIMD::memchr64(unsigned long long const*, unsigned long long, unsigned long)
wasm-ld: error: ./js-compute-runtime/runtime/spidermonkey/debug/lib/libjs_static.a(Unified_cpp_js_src_gc1.o): undefined symbol: printf_stderr
```

This build should show that Fastly's JS Compute Runtime builds with these 3 patches applied -- https://github.com/fastly/js-compute-runtime/actions/runs/8453907665?pr=744