### PR TITLE
Fix AOT ICs: eagerly ensure JitZone is created.

### DIFF
--- a/js/src/gc/GC.cpp
+++ b/js/src/gc/GC.cpp
@@ -5013,6 +5013,16 @@ Realm* js::NewRealm(JSContext* cx, JSPrincipals* principals,
     zone->compartments().infallibleAppend(compHolder.release());
   }
 
+#ifdef ENABLE_JS_AOT_ICS
+  if (zone) {
+      // This is where the AOT IC corpus is loaded. If we do not eagerly force
+      // this, it may not be created when initializing then snapshotting the
+      // engine, because its creation is only otherwise triggered lazily by
+      // execution.
+      zone->ensureJitZoneExists(cx);
+  }
+#endif
+
   if (zoneHolder) {
     rt->gc.zones().infallibleAppend(zoneHolder.release());
 


### PR DESCRIPTION
Somewhere in either the 124..127 rebase or in my move from local JS shell + wizer hack to StarlingMonkey, the way that Zone initialization happens has changed and AOT ICs are no longer preloaded. It seems that the lazy-init creation of the JitZone was only incidentally/fragilely being triggered during wizening before; this PR adds an explicit invocation of `ensureJitZoneExists` in the realm creation flow when the AOT ICs feature is enabled.

Note for future rebases: this should be consolidated into the main AOT ICs patch.