### PR TITLE
PBL: save PC in interpreter frame before all ICs.

### DIFF
--- a/js/src/vm/PortableBaselineInterpret.cpp
+++ b/js/src/vm/PortableBaselineInterpret.cpp
@@ -5821,9 +5821,7 @@ static MOZ_ALWAYS_INLINE EnvironmentObject& getEnvironmentFromCoordinate(
       reinterpret_cast<uintptr_t>(spbase) - reinterpret_cast<uintptr_t>(sp);
 
 #define INVOKE_IC(kind, hasarg2)                                        \
-  if (!Specialized) {                                                   \
-    frame->interpreterPC() = pc;                                        \
-  }                                                                     \
+  frame->interpreterPC() = pc;                                          \
   SYNCSP();                                                             \
   UPDATE_SPOFF();                                                       \
   PBL_CALL_IC(icEntry->rawJitCode(), ctx, icEntry->firstStub(), ic_ret, \


### PR DESCRIPTION
As an optimization in "specialized" variants of the PBL interpreter, stores of the current PC to the PC slot in the interpreter frame are elided; otherwise, we have an extra store for every opcode, with quite significant overhead. (The native baseline compiler makes the same optimization choice, though in the native case, there is the programmatically-observable native return-address PC to indicate location at each frame on the stack.)

We need to store the PC into the interpreter frame whenever an exception might be thrown, because the stack-walker will compare current PC in each frame against the try-notes to determine which try-blocks are in scoep and should catch the exception.

This store-elision optimization applies even before calls to IC chains, even though an IC might invoke arbitrarily complex behavior and throw an exception. Previously, we had supported this case by storing the PC state only if the IC chain returns with an error code, before we dispatch to the `HandleException` path -- just in time.

However, if the IC itself calls more deeply into some other code that may throw an exception and perform its own unwind, our stack frame is observable before we get a chance to fill in this state. So we need to eagerly store PC into the frame every time before we call such an IC.

The canonical IC-site kind that should hit this problem is an actual call opcode, and indeed this was the actual bug I observed; but to be safe, let's store it prior to every IC site, because other ICs may have CacheIR that invokes other JS code in some case (it's better not to try to reason about this and rule out some cases -- too brittle).

Note that the PBL *interpreter* always stores PC before ICs; this is one of the few cases where the "specialized" (wevaled) body explicitly diverges for performance reasons. Hence jit-tests would not have caught it, because we rely on jit-testing the interpreter then trusting weval's semantics-preserving transform (actually wevaling 10k unit-test files would be prohibitively expensive). Let's go for correctness before performance here and remove the divergence.

Discovered via a non-working `try` block in the StarlingMonkey integration suite.