### PR TITLE
PBL: fix specialization range on TableSwitch index.

### DIFF
--- a/js/src/vm/PortableBaselineInterpret.cpp
+++ b/js/src/vm/PortableBaselineInterpret.cpp
@@ -8375,11 +8375,11 @@ PBIResult PortableBaselineInterpret(JSContext* cx_, State& state, Stack& stack,
           DISPATCH();
         }
 
-        i = PBL_SPECIALIZE_VALUE(i - low, low, high);
-
-        if ((uint32_t(i) < uint32_t(high - low + 1))) {
+        if (i >= low && i <= high) {
+          uint32_t idx =
+            PBL_SPECIALIZE_VALUE(uint32_t(i) - uint32_t(low), 0, uint32_t(high - low + 1));
           uint32_t firstResumeIndex = GET_RESUMEINDEX(pc + 3 * JUMP_OFFSET_LEN);
-          pc = entryPC + resumeOffsets[firstResumeIndex + i];
+          pc = entryPC + resumeOffsets[firstResumeIndex + idx];
           DISPATCH();
         }
         ADVANCE(len);


### PR DESCRIPTION
When instructing weval to generate control flow with constant-propagated indices for a TableSwitch, we need to give the proper range; `i - low` has range `0..=(high-low+1)`, not `low..=high` (i.e. it is shifted down by `low`). Also move the intrinsic into the not-out-of-bounds conditional to make the code a little clearer.