### PR TITLE
PBL: a few fixes from investigations of wevaling a debug build.

### DIFF
--- a/js/src/jit/BaselineCacheIRCompiler.cpp
+++ b/js/src/jit/BaselineCacheIRCompiler.cpp
@@ -2650,7 +2650,20 @@ static bool LookupOrCompileStub(JSContext* cx, CacheKind kind,
   }
   MOZ_ASSERT_IF(IsBaselineInterpreterEnabled(), code);
   MOZ_ASSERT(stubInfo);
-  MOZ_ASSERT(stubInfo->stubDataSize() == writer.stubDataSize());
+  // Assert that the StubInfo recomputing its stub-data size exactly
+  // matches the writer's stub-data size, but only if we're not
+  // loading an AOT IC -- otherwise, trust the recomputation from
+  // field types.
+  //
+  // Why ignore if AOT? Because the AOT corpus might have been dumped
+  // on a machine with a different word size than our machine (e.g.,
+  // 64 to 32 bits). The field types are serialized and deserialized,
+  // and they are authoritative; the CacheIRWriter's stubDataSize is
+  // computed during build and used only for this assert, so it is
+  // strictly a redundant check.
+  if (!isAOTFill) {
+    MOZ_ASSERT(stubInfo->stubDataSize() == writer.stubDataSize());
+  }
 
   return true;
 }

--- a/js/src/vm/PortableBaselineInterpret-weval-defs.h
+++ b/js/src/vm/PortableBaselineInterpret-weval-defs.h
@@ -7,6 +7,15 @@
 #ifndef PortableBaselineInerpret_weval_defs_h
 #define PortableBaselineInerpret_weval_defs_h
 
+#ifdef DEBUG
+// weval has to constant-propagate interpreter state well enough to unroll the
+// interpreter loops, and this is not possible in a debug build because the
+// interpreter state is spilled and reloaded to memory (which cannot be tracked
+// in a fine-grained way by cprop). We need C++ locals to live in Wasm locals
+// for weval to work.
+#error PBL weval support only works in optimized (non-debug) builds.
+#endif
+
 /* Basic definitions for PBL's internals that can be swapped out as
  * needed to handle interpreter details differently.
  *


### PR DESCRIPTION
* PBL: make an assert about stubDataSize valid for non-AOT ICs only.

  Assert that the StubInfo recomputing its stub-data size exactly matches the writer's stub-data size, but only if we're not loading an AOT IC -- otherwise, trust the recomputation from field types.

  Why can we ignore the serialized size if AOT? Because the AOT corpus might have been dumped on a machine with a different word size than our machine (e.g., 64 to 32 bits). The field types are serialized and deserialized, and they are authoritative; the CacheIRWriter's stubDataSize is computed during build and used only for this assert, so it is strictly a redundant check.

* PBL: disable weval-enabled builds in debug mode.

  weval has to constant-propagate interpreter state well enough to unroll the interpreter loops, and this is not possible in a debug build because the interpreter state is spilled and reloaded to memory (which cannot be tracked in a fine-grained way by cprop). We need C++ locals to live in Wasm locals for weval to work.

This came from investigations related to bytecodealliance/starlingmonkey#149.